### PR TITLE
Feature/link box

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,6 +4,7 @@ export * from './form-group';
 export * from './icon';
 export * from './input';
 export * from './link';
+export * from './link-box';
 export * from './select';
 export * from './spinner';
 export * from './text-area';

--- a/src/components/link-box/__snapshots__/link-box.test.tsx.snap
+++ b/src/components/link-box/__snapshots__/link-box.test.tsx.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`it renders correctly 1`] = `
+<div>
+  <div
+    class="lbh-link-box"
+  >
+    <div
+      class="lbh-link-overlay"
+    >
+      <a
+        class="govuk-link lbh-link"
+        href="https://localhost"
+      >
+        Link
+      </a>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/link-box/index.ts
+++ b/src/components/link-box/index.ts
@@ -1,0 +1,1 @@
+export * from './link-box';

--- a/src/components/link-box/link-box.test.tsx
+++ b/src/components/link-box/link-box.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { Link } from '../link';
+import { LinkBox, LinkOverlay } from './link-box';
+
+test('it renders correctly', () => {
+  const { container } = render(
+    <LinkBox>
+      <LinkOverlay>
+        <Link href="https://localhost">Link</Link>
+      </LinkOverlay>
+    </LinkBox>
+  );
+
+  expect(container).toMatchSnapshot();
+});

--- a/src/components/link-box/link-box.tsx
+++ b/src/components/link-box/link-box.tsx
@@ -1,0 +1,35 @@
+import React, {
+  ComponentPropsWithoutRef,
+  ReactElement,
+  forwardRef,
+} from 'react';
+import cn from 'classnames';
+
+import { ButtonLinkProps } from '../button-link';
+import { LinkProps } from '../link';
+import './styles.scss';
+
+export interface LinkOverlayProps extends ComponentPropsWithoutRef<'div'> {
+  children: ReactElement<LinkProps | ButtonLinkProps>;
+}
+
+export const LinkOverlay = forwardRef<HTMLDivElement, LinkOverlayProps>(
+  function LinkOverlay({ children, className, ...props }, ref) {
+    return (
+      <div ref={ref} className={cn('lbh-link-overlay', className)} {...props}>
+        {children}
+      </div>
+    );
+  }
+);
+
+export const LinkBox = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<'div'>
+>(function LinkBox({ children, className, ...props }, ref) {
+  return (
+    <div ref={ref} className={cn('lbh-link-box', className)} {...props}>
+      {children}
+    </div>
+  );
+});

--- a/src/components/link-box/styles.scss
+++ b/src/components/link-box/styles.scss
@@ -1,0 +1,25 @@
+.lbh-link-overlay a {
+  position: static;
+
+  &:before {
+    content: '';
+    cursor: inherit;
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 0;
+    width: 100%;
+    height: 100%;
+  }
+}
+
+.lbh-link-box {
+  position: relative;
+
+  a[href]:not(.lbh-link-box a),
+  abbr[title] {
+    position: relative;
+    z-index: 1;
+  }
+}

--- a/src/components/link/link.tsx
+++ b/src/components/link/link.tsx
@@ -37,12 +37,13 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     className
   );
   return (
+    // eslint-disable-next-line react/jsx-no-target-blank
     <a
       ref={ref}
       href={href}
       className={linkClasses}
       rel={isExternal ? 'noopener noreferrer' : rel}
-      target={isExternal ? '_blanl' : target}
+      target={isExternal ? '_blank' : target}
       onClick={!isExternal ? navigateToUrl : undefined}
       {...props}
     >

--- a/src/components/link/link.tsx
+++ b/src/components/link/link.tsx
@@ -14,8 +14,18 @@ export interface LinkProps extends ComponentPropsWithoutRef<'a'> {
     | 'native';
   isExternal?: boolean;
 }
+
 export const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
-  { variant = 'link', isExternal = false, href, className, children, ...props },
+  {
+    variant = 'link',
+    isExternal = false,
+    href,
+    className,
+    children,
+    rel,
+    target,
+    ...props
+  },
   ref
 ) {
   const linkClasses = cn(
@@ -31,6 +41,8 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
       ref={ref}
       href={href}
       className={linkClasses}
+      rel={isExternal ? 'noopener noreferrer' : rel}
+      target={isExternal ? '_blanl' : target}
       onClick={!isExternal ? navigateToUrl : undefined}
       {...props}
     >


### PR DESCRIPTION
Add `link-box` components.

Allows us to keep semantic html with a priority on accessibility for making wrapping components clickable from a nested anchor tag.

```tsx
<Linkbox>
    <h1>Heading</h1>
    <img src="image.png" alt="image" />
    <LinkOverlay>
        <Link href="http://localhost">Click here</Link>
    </LinkOverlay>
</LinkBox>
``` 