### PR TITLE
fix(components): Better handling for nested array children

### DIFF
--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -42,12 +42,14 @@ export const AccordionItem = forwardRef<HTMLDivElement, AccordionItemProps>(
   }
 );
 
+type AccordionChild =
+  | ReactElement<AccordionItemProps>
+  | ReactElement<AccordionItemProps>[]
+  | null;
+
 interface AccordionProps extends ComponentPropsWithoutRef<'div'> {
   id: string;
-  children:
-    | ReactElement<AccordionItemProps>
-    | null
-    | Array<ReactElement<AccordionItemProps> | null>;
+  children: AccordionChild | AccordionChild[];
   defaultIndex?: number;
   visuallyHideControls?: boolean;
 }

--- a/src/components/summary-list/summary-list.tsx
+++ b/src/components/summary-list/summary-list.tsx
@@ -75,13 +75,15 @@ export const SummaryListItem = forwardRef<HTMLDivElement, SummaryListItemProps>(
   }
 );
 
+type SummaryListChild =
+  | ReactElement<SummaryListItemProps>
+  | ReactElement<SummaryListItemProps>[]
+  | null;
+
 export interface SummaryListProps extends ComponentPropsWithoutRef<'dl'> {
   variant?: 'base' | 'border';
   overrides?: number[];
-  children:
-    | ReactElement<SummaryListItemProps>
-    | null
-    | Array<ReactElement<SummaryListItemProps> | null>;
+  children: SummaryListChild | SummaryListChild[];
 }
 
 export const SummaryList = forwardRef<HTMLDListElement, SummaryListProps>(


### PR DESCRIPTION
Adds support for nested child arrays for select components that expect children of a particular shape.

```tsx
<Accordion>
  <AccordionItem ... />
  {list.map(item => <AccordionItem key={item} ... />}
  {isTrue ? <AccordionItem ... /> : null}
</Accordion>
```
