### PR TITLE
feat(api): add request headers for logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@testing-library/react-hooks": "^6.0.0",
     "@testing-library/user-event": "^13.1.9",
     "@types/jest-axe": "^3.5.1",
+    "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "4.26.0",
     "@typescript-eslint/parser": "4.26.0",
     "axe-core": "^4.2.2",
@@ -91,7 +92,8 @@
     "rxjs": "^7.0.1",
     "single-spa": "^5.9.3",
     "swr": "^0.5.6",
-    "use-breakpoint": "^2.0.1"
+    "use-breakpoint": "^2.0.1",
+    "uuid": "^8.3.2"
   },
   "peerDependencies": {
     "react": ">=17.0.2",

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosError, CancelTokenSource } from 'axios';
+import { v4 as uuid } from 'uuid';
 
 import { $auth, logout } from '../auth';
 
@@ -6,13 +7,18 @@ const axiosInstance = axios.create({
   responseType: 'json',
 });
 
-axiosInstance.interceptors.request.use((config) => ({
-  ...config,
-  headers: {
-    ...(config.headers as Headers),
-    Authorization: `Bearer ${$auth.getValue().token}`,
-  },
-}));
+axiosInstance.interceptors.request.use((config) => {
+  const auth = $auth.getValue();
+  return {
+    ...config,
+    headers: {
+      ...(config.headers as Headers),
+      Authorization: `Bearer ${auth.token}`,
+      'X-Correlation-ID': uuid(),
+      'X-User-ID': auth.sub,
+    },
+  };
+});
 
 axiosInstance.interceptors.response.use(
   (res) => res,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1640,6 +1640,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/uuid@^8.3.0":
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
+  integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
+
 "@types/webpack-env@^1.16.0":
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.16.0.tgz#8c0a9435dfa7b3b1be76562f3070efb3f92637b4"
@@ -8577,7 +8582,7 @@ uuid@^3.3.2, uuid@^3.4.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.3.0:
+uuid@^8.3.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
Adds `X-Correlation-ID` and `X-User-ID` headers to requests.

X-Correlation-ID uses [v4 uuid](https://github.com/uuidjs/uuid#uuidv4options-buffer-offset)
Meaning it is random, but not impossible for collisions. [See an example](https://github.com/uuidjs/uuid#duplicate-uuids-googlebot)