### PR TITLE
feat(comps): make relevant components polymorphic

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
   },
   "dependencies": {
     "@babel/preset-react": "^7.13.13",
+    "@radix-ui/react-polymorphic": "^0.0.12",
     "@reach/dialog": "^0.15.0",
     "@types/jest": "^26.0.16",
     "@types/js-cookie": "^2.2.6",

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -1,25 +1,32 @@
-import React, {
-  ComponentPropsWithoutRef,
-  ReactElement,
-  forwardRef,
-  useEffect,
-  useRef,
-} from 'react';
+import React, { ReactElement, forwardRef, useEffect, useRef } from 'react';
+import type * as Polymoprphic from '@radix-ui/react-polymorphic';
 import cn from 'classnames';
 import { Accordion as AccordionJs } from 'lbh-frontend';
 import mergeRefs from 'react-merge-refs';
 
+import { widthOverrides } from '../../utils';
 import './styles.scss';
 
-export interface AccordionItemProps extends ComponentPropsWithoutRef<'div'> {
+export interface AccordionItemProps {
   id: string;
   title: string;
 }
 
-export const AccordionItem = forwardRef<HTMLDivElement, AccordionItemProps>(
-  function AccordionItem({ children, className, id, title }, ref) {
+export type AccordionItemComponent = Polymoprphic.ForwardRefComponent<
+  'div',
+  AccordionItemProps
+>;
+
+export const AccordionItem: AccordionItemComponent = forwardRef(
+  function AccordionItem(
+    { as: AccordionItemComp = 'div', children, className, id, title },
+    ref
+  ) {
     return (
-      <div ref={ref} className={cn('govuk-accordion__section', className)}>
+      <AccordionItemComp
+        ref={ref}
+        className={cn('govuk-accordion__section', className)}
+      >
         <div className="govuk-accordion__section-header">
           <h3 className="govuk-accordion__section-heading lbh-heading-h5">
             <span
@@ -37,7 +44,7 @@ export const AccordionItem = forwardRef<HTMLDivElement, AccordionItemProps>(
         >
           {children}
         </div>
-      </div>
+      </AccordionItemComp>
     );
   }
 );
@@ -47,58 +54,74 @@ type AccordionChild =
   | ReactElement<AccordionItemProps>[]
   | null;
 
-interface AccordionProps extends ComponentPropsWithoutRef<'div'> {
+export interface AccordionProps {
   id: string;
   children: AccordionChild | AccordionChild[];
   defaultIndex?: number;
   visuallyHideControls?: boolean;
+  override?: number;
 }
 
-export const Accordion = forwardRef<HTMLDivElement, AccordionProps>(
-  function Accordion(
-    { className, defaultIndex, visuallyHideControls = false, ...props },
-    ref
-  ) {
-    const localRef = useRef<HTMLDivElement>(null);
-    const defaultIndexRef = useRef<number | undefined>(defaultIndex);
+export type AccordionComponent = Polymoprphic.ForwardRefComponent<
+  'div',
+  AccordionProps
+>;
 
-    useEffect(() => {
-      if (localRef.current) {
-        const acc = new AccordionJs(localRef.current);
-        acc.init();
+export const Accordion: AccordionComponent = forwardRef(function Accordion(
+  {
+    as: AccordionComp = 'div',
+    className,
+    defaultIndex,
+    override,
+    visuallyHideControls = false,
+    ...props
+  },
+  ref
+) {
+  const localRef = useRef<HTMLElement>(null);
+  const defaultIndexRef = useRef<number | undefined>(defaultIndex);
 
-        if (defaultIndexRef.current !== undefined) {
-          const section = acc.$sections.item(defaultIndexRef.current);
-          if (section) {
-            const button = section.querySelector<HTMLButtonElement>(
-              `.${acc.sectionButtonClass}`
-            );
-            if (button) {
-              const contentId = button.getAttribute('aria-controls');
-              if (contentId && !window.sessionStorage.getItem(contentId)) {
-                acc.setExpanded(
-                  true,
-                  acc.$sections.item(defaultIndexRef.current)
-                );
-              }
+  useEffect(() => {
+    /* istanbul ignore else */
+    if (localRef.current) {
+      const acc = new AccordionJs(localRef.current);
+      acc.init();
+      /* istanbul ignore else */
+      if (defaultIndexRef.current !== undefined) {
+        const section = acc.$sections.item(defaultIndexRef.current);
+        /* istanbul ignore else */
+        if (section) {
+          const button = section.querySelector<HTMLButtonElement>(
+            `.${acc.sectionButtonClass}`
+          );
+          /* istanbul ignore else */
+          if (button) {
+            const contentId = button.getAttribute('aria-controls');
+            /* istanbul ignore else */
+            if (contentId && !window.sessionStorage.getItem(contentId)) {
+              acc.setExpanded(
+                true,
+                acc.$sections.item(defaultIndexRef.current)
+              );
             }
           }
         }
       }
-    }, []);
+    }
+  }, []);
 
-    return (
-      <div
-        className={cn(
-          'govuk-accordion',
-          'lbh-accordion',
-          { 'lbh-accordion--hide-controls': visuallyHideControls },
-          className
-        )}
-        data-attribute="value"
-        ref={mergeRefs([localRef, ref])}
-        {...props}
-      />
-    );
-  }
-);
+  return (
+    <AccordionComp
+      className={cn(
+        'govuk-accordion',
+        'lbh-accordion',
+        { 'lbh-accordion--hide-controls': visuallyHideControls },
+        widthOverrides(override),
+        className
+      )}
+      data-attribute="value"
+      ref={mergeRefs([localRef, ref])}
+      {...props}
+    />
+  );
+});

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, forwardRef, useEffect, useRef } from 'react';
-import type * as Polymoprphic from '@radix-ui/react-polymorphic';
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
 import cn from 'classnames';
 import { Accordion as AccordionJs } from 'lbh-frontend';
 import mergeRefs from 'react-merge-refs';
@@ -12,7 +12,7 @@ export interface AccordionItemProps {
   title: string;
 }
 
-export type AccordionItemComponent = Polymoprphic.ForwardRefComponent<
+export type AccordionItemComponent = Polymorphic.ForwardRefComponent<
   'div',
   AccordionItemProps
 >;
@@ -62,7 +62,7 @@ export interface AccordionProps {
   override?: number;
 }
 
-export type AccordionComponent = Polymoprphic.ForwardRefComponent<
+export type AccordionComponent = Polymorphic.ForwardRefComponent<
   'div',
   AccordionProps
 >;

--- a/src/components/button/button.test.tsx
+++ b/src/components/button/button.test.tsx
@@ -4,8 +4,6 @@ import { render, screen } from '@testing-library/react';
 import { testA11y } from '../../test-utils';
 import { Button } from './button';
 
-jest.mock('single-spa');
-
 test('it renders correctly', async () => {
   const { container } = render(<Button>Test Button</Button>);
   expect(container).toMatchSnapshot();

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -1,57 +1,65 @@
-import React, { ComponentPropsWithoutRef, forwardRef } from 'react';
+import React, { forwardRef } from 'react';
+import type * as Polymoprphic from '@radix-ui/react-polymorphic';
 import cn from 'classnames';
 
+import { widthOverrides } from '../../utils';
 import './styles.scss';
 
-export interface ButtonProps extends ComponentPropsWithoutRef<'button'> {
-  isOverride?: boolean;
+export interface ButtonProps {
   variant?: 'primary' | 'secondary';
   isLoading?: boolean;
   isDisabled?: boolean;
   loadingText?: string;
+  override?: number;
 }
 
-export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  function Button(
+export type ButtonComponent = Polymoprphic.ForwardRefComponent<
+  'button',
+  ButtonProps
+>;
+
+export const Button: ButtonComponent = forwardRef(function Button(
+  {
+    as: ButtonComp = 'button',
+    variant = 'primary',
+    isLoading = false,
+    loadingText,
+    isDisabled,
+    children,
+    className,
+    override,
+    ...props
+  },
+  ref
+) {
+  const buttonClasses = cn(
+    'govuk-button',
+    'lbh-button',
     {
-      variant = 'primary',
-      isLoading = false,
-      loadingText,
-      isDisabled,
-      children,
-      className,
-      ...props
+      'govuk-secondary lbh-button--secondary': variant === 'secondary',
+      'lbh-button--disabled govuk-button--disabled': isDisabled,
     },
-    ref
-  ) {
-    const buttonClasses = cn(
-      'govuk-button',
-      'lbh-button',
-      {
-        'govuk-secondary lbh-button--secondary': variant === 'secondary',
-        'lbh-button--disabled govuk-button--disabled': isDisabled,
-      },
-      className
-    );
+    widthOverrides(override),
+    className
+  );
 
-    const maybeDisable = isDisabled || isLoading || undefined;
+  const maybeDisable = isDisabled || isLoading || undefined;
 
-    return (
-      <button
-        ref={ref}
-        type="button"
-        className={buttonClasses}
-        disabled={maybeDisable}
-        aria-disabled={maybeDisable}
-        {...props}
-      >
-        {isLoading && (
-          <span className="button-loading-indicator">
-            <span>Loading...</span>
-          </span>
-        )}
-        {isLoading && loadingText ? loadingText : children}
-      </button>
-    );
-  }
-);
+  return (
+    <ButtonComp
+      ref={ref}
+      type="button"
+      className={buttonClasses}
+      disabled={maybeDisable}
+      aria-disabled={maybeDisable}
+      {...props}
+    >
+      {isLoading && (
+        <span className="button-loading-indicator">
+          <span>Loading...</span>
+        </span>
+      )}
+      {isLoading && loadingText ? loadingText : children}
+    </ButtonComp>
+  );
+});

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from 'react';
-import type * as Polymoprphic from '@radix-ui/react-polymorphic';
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
 import cn from 'classnames';
 
 import { widthOverrides } from '../../utils';
@@ -13,7 +13,7 @@ export interface ButtonProps {
   override?: number;
 }
 
-export type ButtonComponent = Polymoprphic.ForwardRefComponent<
+export type ButtonComponent = Polymorphic.ForwardRefComponent<
   'button',
   ButtonProps
 >;
@@ -43,15 +43,15 @@ export const Button: ButtonComponent = forwardRef(function Button(
     className
   );
 
-  const maybeDisable = isDisabled || isLoading || undefined;
+  const disabled = isDisabled || isLoading || undefined;
 
   return (
     <ButtonComp
       ref={ref}
       type="button"
       className={buttonClasses}
-      disabled={maybeDisable}
-      aria-disabled={maybeDisable}
+      disabled={disabled}
+      aria-disabled={disabled}
       {...props}
     >
       {isLoading && (

--- a/src/components/center/center.tsx
+++ b/src/components/center/center.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from 'react';
-import type * as Polymoprphic from '@radix-ui/react-polymorphic';
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
 import cn from 'classnames';
 
 import { widthOverrides } from '../../utils';
@@ -11,7 +11,7 @@ export interface CenterProps {
   override?: number;
 }
 
-export type CenterComponent = Polymoprphic.ForwardRefComponent<
+export type CenterComponent = Polymorphic.ForwardRefComponent<
   'div',
   CenterProps
 >;

--- a/src/components/center/center.tsx
+++ b/src/components/center/center.tsx
@@ -1,19 +1,34 @@
-import React, { ComponentPropsWithoutRef, forwardRef } from 'react';
+import React, { forwardRef } from 'react';
+import type * as Polymoprphic from '@radix-ui/react-polymorphic';
 import cn from 'classnames';
 
+import { widthOverrides } from '../../utils';
 import './styles.scss';
 
-export interface CenterProps extends ComponentPropsWithoutRef<'div'> {
+export interface CenterProps {
   horizontally?: boolean;
   vertically?: boolean;
+  override?: number;
 }
 
-export const Center = forwardRef<HTMLDivElement, CenterProps>(function Center(
-  { horizontally = true, vertically = true, className, ...props },
+export type CenterComponent = Polymoprphic.ForwardRefComponent<
+  'div',
+  CenterProps
+>;
+
+export const Center: CenterComponent = forwardRef(function Center(
+  {
+    as: CenterComp = 'div',
+    horizontally = true,
+    vertically = true,
+    className,
+    override,
+    ...props
+  },
   ref
 ) {
   return (
-    <div
+    <CenterComp
       ref={ref}
       className={cn(
         'mtfh-center',
@@ -21,6 +36,7 @@ export const Center = forwardRef<HTMLDivElement, CenterProps>(function Center(
           'mtfh-center--horizontal': horizontally,
           'mtfh-center--vertical': vertically,
         },
+        widthOverrides(override),
         className
       )}
       {...props}

--- a/src/components/checkboxes/checkboxes.tsx
+++ b/src/components/checkboxes/checkboxes.tsx
@@ -86,6 +86,7 @@ export const CheckboxGroup = forwardRef<HTMLDivElement, CheckboxGroupProps>(
     const localRef = useRef<HTMLDivElement>();
 
     useEffect(() => {
+      /* istanbul ignore else */
       if (localRef.current) {
         new Checkboxes(localRef.current).init();
       }

--- a/src/components/dialog/styles.scss
+++ b/src/components/dialog/styles.scss
@@ -1,6 +1,10 @@
 @import '~lbh-frontend/lbh/base';
 @import '~lbh-frontend/lbh/components/lbh-dialog/_dialog.scss';
 
+[data-reach-dialog-overlay] {
+  z-index: 100;
+}
+
 .lbh-dialog__close {
   margin-top: 1.5rem;
   margin-right: 1.5rem;

--- a/src/components/error-summary/error-summary.tsx
+++ b/src/components/error-summary/error-summary.tsx
@@ -7,13 +7,15 @@ import React, {
   useEffect,
   useRef,
 } from 'react';
+import type * as Polymoprphic from '@radix-ui/react-polymorphic';
 import cn from 'classnames';
 import { ErrorSummary as ErrorSummaryJs } from 'lbh-frontend';
 import mergeRefs from 'react-merge-refs';
 
+import { widthOverrides } from '../../utils';
 import './styles.scss';
 
-export interface ErrorSummaryProps extends ComponentPropsWithoutRef<'div'> {
+export interface ErrorSummaryProps {
   id: string;
   title: string;
   description?: string;
@@ -22,16 +24,33 @@ export interface ErrorSummaryProps extends ComponentPropsWithoutRef<'div'> {
     | ReactElement<ComponentProps<'a'>>
     | null
     | Array<ReactElement<ComponentProps<'a'>> | null>;
+  override?: number;
 }
 
-export const ErrorSummary = forwardRef<HTMLDivElement, ErrorSummaryProps>(
+export type ErrorSummaryComponent = Polymoprphic.ForwardRefComponent<
+  'div',
+  ErrorSummaryProps
+>;
+
+export const ErrorSummary: ErrorSummaryComponent = forwardRef(
   function ErrorSummary(
-    { id, title, description, className, children, reFocus, ...props },
+    {
+      as: ErrorSummaryComp = 'div',
+      id,
+      title,
+      description,
+      className,
+      children,
+      reFocus,
+      override,
+      ...props
+    },
     ref
   ) {
-    const localRef = useRef<HTMLDivElement>();
+    const localRef = useRef<HTMLElement>(null);
 
     useEffect(() => {
+      /* istanbul ignore else */
       if (localRef.current) {
         // eslint-disable-next-line no-new
         new ErrorSummaryJs(localRef.current);
@@ -40,15 +59,21 @@ export const ErrorSummary = forwardRef<HTMLDivElement, ErrorSummaryProps>(
     }, []);
 
     useEffect(() => {
+      /* istanbul ignore else */
       if (localRef.current) {
         localRef.current.scrollIntoView(true);
       }
     }, [reFocus]);
 
     return (
-      <div
+      <ErrorSummaryComp
         ref={mergeRefs([localRef, ref])}
-        className={cn('govuk-error-summary', className, 'lbh-error-summary')}
+        className={cn(
+          'govuk-error-summary',
+          'lbh-error-summary',
+          widthOverrides(override),
+          className
+        )}
         aria-labelledby={id}
         role="alert"
         {...props}
@@ -69,7 +94,7 @@ export const ErrorSummary = forwardRef<HTMLDivElement, ErrorSummaryProps>(
             ) : null}
           </div>
         ) : null}
-      </div>
+      </ErrorSummaryComp>
     );
   }
 );

--- a/src/components/error-summary/error-summary.tsx
+++ b/src/components/error-summary/error-summary.tsx
@@ -1,13 +1,12 @@
 import React, {
   ComponentProps,
-  ComponentPropsWithoutRef,
   ReactElement,
   forwardRef,
   isValidElement,
   useEffect,
   useRef,
 } from 'react';
-import type * as Polymoprphic from '@radix-ui/react-polymorphic';
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
 import cn from 'classnames';
 import { ErrorSummary as ErrorSummaryJs } from 'lbh-frontend';
 import mergeRefs from 'react-merge-refs';
@@ -27,7 +26,7 @@ export interface ErrorSummaryProps {
   override?: number;
 }
 
-export type ErrorSummaryComponent = Polymoprphic.ForwardRefComponent<
+export type ErrorSummaryComponent = Polymorphic.ForwardRefComponent<
   'div',
   ErrorSummaryProps
 >;

--- a/src/components/fieldset/fieldset.tsx
+++ b/src/components/fieldset/fieldset.tsx
@@ -7,6 +7,7 @@ import React, {
 } from 'react';
 import cn from 'classnames';
 
+import { widthOverrides } from '../../utils';
 import './styles.scss';
 
 export interface FieldsetProps extends ComponentPropsWithoutRef<'fieldset'> {
@@ -14,6 +15,7 @@ export interface FieldsetProps extends ComponentPropsWithoutRef<'fieldset'> {
   variant?: 'base' | 'small' | 'medium' | 'large' | 'xlarge' | 'hidden';
   indent?: boolean;
   error?: boolean | string;
+  override?: number;
 }
 
 export const Fieldset = forwardRef<HTMLFieldSetElement, FieldsetProps>(
@@ -25,6 +27,7 @@ export const Fieldset = forwardRef<HTMLFieldSetElement, FieldsetProps>(
       heading,
       children,
       className,
+      override,
       ...props
     },
     ref
@@ -39,6 +42,7 @@ export const Fieldset = forwardRef<HTMLFieldSetElement, FieldsetProps>(
             'mtfh-fieldset--indent': indent,
             'mtfh-fieldset--error': !!error,
           },
+          widthOverrides(override),
           className
         )}
         {...props}

--- a/src/components/form-group/form-group.tsx
+++ b/src/components/form-group/form-group.tsx
@@ -9,6 +9,7 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 
+import { widthOverrides } from '../../utils';
 import { TextArea } from '../text-area';
 import './styles.scss';
 
@@ -20,11 +21,23 @@ export interface FormGroupProps extends ComponentPropsWithoutRef<'div'> {
   error?: string | false;
   required?: boolean;
   children: ReactElement;
+  override?: number;
 }
 
 export const FormGroup = forwardRef<HTMLDivElement, FormGroupProps>(
   function FormGroup(
-    { id, name, label, hint, error, required, children, className, ...props },
+    {
+      id,
+      name,
+      label,
+      hint,
+      error,
+      required,
+      children,
+      className,
+      override,
+      ...props
+    },
     ref
   ) {
     const formGroupClasses = classNames(
@@ -33,6 +46,7 @@ export const FormGroup = forwardRef<HTMLDivElement, FormGroupProps>(
         'govuk-form-group--error': !!error,
       },
       'lbh-form-group',
+      widthOverrides(override),
       className
     );
 

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -1,14 +1,16 @@
 import React, { ComponentPropsWithoutRef, forwardRef } from 'react';
 import classNames from 'classnames';
 
+import { widthOverrides } from '../../utils';
 import './styles.scss';
 
 export interface InputProps extends ComponentPropsWithoutRef<'input'> {
   error?: boolean;
+  override?: number;
 }
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
-  { error, className, ...props },
+  { error, className, override, ...props },
   ref
 ) {
   const inputClasses = classNames(
@@ -17,6 +19,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
     {
       'govuk-input--error': error,
     },
+    widthOverrides(override),
     className
   );
 

--- a/src/components/layout/__snapshots__/layout.test.tsx.snap
+++ b/src/components/layout/__snapshots__/layout.test.tsx.snap
@@ -5,12 +5,6 @@ exports[`it renders correctly 1`] = `
   <div
     class="mtfh-layout"
   >
-    <a
-      class="govuk-back-link lbh-back-link lbh-link--no-visited-state"
-      href="http://localhost"
-    >
-      Back
-    </a>
     <div
       id="top"
     >
@@ -47,12 +41,6 @@ exports[`it renders correctly without a side 1`] = `
   <div
     class="mtfh-layout mtfh-layout--narrow"
   >
-    <a
-      class="govuk-back-link lbh-back-link lbh-link--no-visited-state"
-      href="http://localhost"
-    >
-      Back
-    </a>
     <div
       class="mtfh-layout__container"
     >

--- a/src/components/layout/layout.test.tsx
+++ b/src/components/layout/layout.test.tsx
@@ -6,12 +6,7 @@ import { Layout } from './layout';
 
 test('it renders correctly', async () => {
   const { container } = render(
-    <Layout
-      backLabel="Back"
-      backLink="http://localhost"
-      side={<div id="side">Side Bar</div>}
-      top={<div id="top">Top</div>}
-    >
+    <Layout side={<div id="side">Side Bar</div>} top={<div id="top">Top</div>}>
       <div id="main">Main</div>
     </Layout>
   );
@@ -21,7 +16,7 @@ test('it renders correctly', async () => {
 
 test('it renders correctly without a side', () => {
   const { container } = render(
-    <Layout backLabel="Back" backLink="http://localhost">
+    <Layout>
       <div id="main">Main</div>
     </Layout>
   );

--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -5,18 +5,15 @@ import React, {
 } from 'react';
 import cn from 'classnames';
 
-import { Link } from '../link';
 import './styles.scss';
 
 export interface LayoutProps extends ComponentPropsWithoutRef<'div'> {
-  backLabel: string;
-  backLink: string;
   top?: ReactElement;
   side?: ReactElement;
 }
 
 export const Layout = forwardRef<HTMLDivElement, LayoutProps>(function Layout(
-  { backLabel, backLink, children, top, side, className, ...props },
+  { children, top, side, className, ...props },
   ref
 ) {
   return (
@@ -25,9 +22,6 @@ export const Layout = forwardRef<HTMLDivElement, LayoutProps>(function Layout(
       className={cn('mtfh-layout', { 'mtfh-layout--narrow': !side }, className)}
       {...props}
     >
-      <Link href={backLink} variant="back-link">
-        {backLabel}
-      </Link>
       {top}
       <div className="mtfh-layout__container">
         {side ? <div className="mtfh-layout__aside">{side}</div> : null}

--- a/src/components/link-box/link-box.tsx
+++ b/src/components/link-box/link-box.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, forwardRef } from 'react';
-import type * as Polymoprphic from '@radix-ui/react-polymorphic';
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
 import cn from 'classnames';
 
 import { widthOverrides } from '../../utils';
@@ -12,7 +12,7 @@ export interface LinkOverlayProps {
   override?: number;
 }
 
-export type LinkOverlayComponent = Polymoprphic.ForwardRefComponent<
+export type LinkOverlayComponent = Polymorphic.ForwardRefComponent<
   'div',
   LinkOverlayProps
 >;
@@ -36,7 +36,7 @@ export interface LinkBoxProps {
   override?: number;
 }
 
-export type LinkBoxComponent = Polymoprphic.ForwardRefComponent<
+export type LinkBoxComponent = Polymorphic.ForwardRefComponent<
   'div',
   LinkBoxProps
 >;

--- a/src/components/link-box/link-box.tsx
+++ b/src/components/link-box/link-box.tsx
@@ -1,35 +1,55 @@
-import React, {
-  ComponentPropsWithoutRef,
-  ReactElement,
-  forwardRef,
-} from 'react';
+import React, { ReactElement, forwardRef } from 'react';
+import type * as Polymoprphic from '@radix-ui/react-polymorphic';
 import cn from 'classnames';
 
+import { widthOverrides } from '../../utils';
 import { ButtonLinkProps } from '../button-link';
 import { LinkProps } from '../link';
 import './styles.scss';
 
-interface LinkOverlayProps extends ComponentPropsWithoutRef<'div'> {
+export interface LinkOverlayProps {
   children: ReactElement<LinkProps | ButtonLinkProps>;
+  override?: number;
 }
 
-export const LinkOverlay = forwardRef<HTMLDivElement, LinkOverlayProps>(
-  function LinkOverlay({ children, className, ...props }, ref) {
+export type LinkOverlayComponent = Polymoprphic.ForwardRefComponent<
+  'div',
+  LinkOverlayProps
+>;
+
+export const LinkOverlay: LinkOverlayComponent = forwardRef(
+  function LinkOverlay(
+    { as: LinkOverlayComp = 'div', className, override, ...props },
+    ref
+  ) {
     return (
-      <div ref={ref} className={cn('mtfh-link-overlay', className)} {...props}>
-        {children}
-      </div>
+      <LinkOverlayComp
+        ref={ref}
+        className={cn('mtfh-link-overlay', widthOverrides(override), className)}
+        {...props}
+      />
     );
   }
 );
 
-export const LinkBox = forwardRef<
-  HTMLDivElement,
-  ComponentPropsWithoutRef<'div'>
->(function LinkBox({ children, className, ...props }, ref) {
+export interface LinkBoxProps {
+  override?: number;
+}
+
+export type LinkBoxComponent = Polymoprphic.ForwardRefComponent<
+  'div',
+  LinkBoxProps
+>;
+
+export const LinkBox: LinkBoxComponent = forwardRef(function LinkBox(
+  { as: LinkBoxComp = 'div', className, override, ...props },
+  ref
+) {
   return (
-    <div ref={ref} className={cn('mtfh-link-box', className)} {...props}>
-      {children}
-    </div>
+    <LinkBoxComp
+      ref={ref}
+      className={cn('mtfh-link-box', widthOverrides(override), className)}
+      {...props}
+    />
   );
 });

--- a/src/components/link/link.tsx
+++ b/src/components/link/link.tsx
@@ -1,10 +1,11 @@
-import React, { ComponentPropsWithoutRef, forwardRef } from 'react';
+import React, { forwardRef } from 'react';
+import type * as Polymoprphic from '@radix-ui/react-polymorphic';
 import cn from 'classnames';
-import { navigateToUrl } from 'single-spa';
 
+import { widthOverrides } from '../../utils';
 import './styles.scss';
 
-export interface LinkProps extends ComponentPropsWithoutRef<'a'> {
+export interface LinkProps {
   variant?:
     | 'link'
     | 'danger'
@@ -13,17 +14,20 @@ export interface LinkProps extends ComponentPropsWithoutRef<'a'> {
     | 'back-link'
     | 'native';
   isExternal?: boolean;
+  override?: number;
 }
 
-export const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
+export type LinkComponent = Polymoprphic.ForwardRefComponent<'a', LinkProps>;
+
+export const Link: LinkComponent = forwardRef(function Link(
   {
+    as: LinkComp = 'a',
     variant = 'link',
     isExternal = false,
-    href,
     className,
-    children,
     rel,
     target,
+    override,
     ...props
   },
   ref
@@ -35,20 +39,17 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
       [`lbh-link--${variant}`]: variant !== 'link' && variant !== 'back-link',
       'lbh-link--no-visited-state': !isExternal,
     },
+    widthOverrides(override),
     className
   );
   return (
     // eslint-disable-next-line react/jsx-no-target-blank
-    <a
+    <LinkComp
       ref={ref}
-      href={href}
       className={linkClasses}
       rel={isExternal ? 'noopener noreferrer' : rel}
       target={isExternal ? '_blank' : target}
-      onClick={!isExternal ? navigateToUrl : undefined}
       {...props}
-    >
-      {children}
-    </a>
+    />
   );
 });

--- a/src/components/link/link.tsx
+++ b/src/components/link/link.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from 'react';
-import type * as Polymoprphic from '@radix-ui/react-polymorphic';
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
 import cn from 'classnames';
 
 import { widthOverrides } from '../../utils';
@@ -17,7 +17,7 @@ export interface LinkProps {
   override?: number;
 }
 
-export type LinkComponent = Polymoprphic.ForwardRefComponent<'a', LinkProps>;
+export type LinkComponent = Polymorphic.ForwardRefComponent<'a', LinkProps>;
 
 export const Link: LinkComponent = forwardRef(function Link(
   {

--- a/src/components/radios/radios.tsx
+++ b/src/components/radios/radios.tsx
@@ -103,6 +103,7 @@ export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
     const localRef = useRef<HTMLDivElement>();
 
     useEffect(() => {
+      /* istanbul ignore else */
       if (localRef.current) {
         new RadiosJs(localRef.current).init();
       }

--- a/src/components/select/__snapshots__/select.spec.tsx.snap
+++ b/src/components/select/__snapshots__/select.spec.tsx.snap
@@ -43,11 +43,3 @@ exports[`it renders correctly with error 1`] = `
   />
 </div>
 `;
-
-exports[`it renders correctly with isFullWidth 1`] = `
-<div>
-  <select
-    class="govuk-select govuk-!-width-full lbh-select"
-  />
-</div>
-`;

--- a/src/components/select/select.spec.tsx
+++ b/src/components/select/select.spec.tsx
@@ -26,8 +26,3 @@ test('it renders correctly with error', () => {
   const { container } = render(<Select error />);
   expect(container).toMatchSnapshot();
 });
-
-test('it renders correctly with isFullWidth', () => {
-  const { container } = render(<Select isFullWidth />);
-  expect(container).toMatchSnapshot();
-});

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -1,20 +1,21 @@
 import React, { ComponentPropsWithoutRef, forwardRef } from 'react';
 import classNames from 'classnames';
 
+import { widthOverrides } from '../../utils';
 import './styles.scss';
 
 export interface SelectProps extends ComponentPropsWithoutRef<'select'> {
   error?: boolean;
-  isFullWidth?: boolean;
+  override?: number;
 }
 
 export const Select = forwardRef<HTMLSelectElement, SelectProps>(
-  function Select({ error, className, isFullWidth, ...props }, ref) {
+  function Select({ error, className, override, ...props }, ref) {
     const selectClasses = classNames(
       'govuk-select',
-      { 'govuk-!-width-full': isFullWidth },
       'lbh-select',
       { 'govuk-select--error': error },
+      widthOverrides(override),
       className
     );
     return <select ref={ref} className={selectClasses} {...props} />;

--- a/src/components/side-bar/side-bar.tsx
+++ b/src/components/side-bar/side-bar.tsx
@@ -5,7 +5,7 @@ import React, {
   forwardRef,
   isValidElement,
 } from 'react';
-import type * as Polymoprphic from '@radix-ui/react-polymorphic';
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
 import cn from 'classnames';
 
 import { useBreakpoint } from '../../hooks';
@@ -17,7 +17,7 @@ export interface SideBarSectionProps extends AccordionItemProps {
   heading?: string;
 }
 
-export type SideBarSectionComponent = Polymoprphic.ForwardRefComponent<
+export type SideBarSectionComponent = Polymorphic.ForwardRefComponent<
   'div',
   SideBarSectionProps
 >;
@@ -57,7 +57,7 @@ export interface SideBarProps {
     | Array<ReactElement<SideBarSectionProps> | null>;
 }
 
-export type SideBarComponent = Polymoprphic.ForwardRefComponent<
+export type SideBarComponent = Polymorphic.ForwardRefComponent<
   'div',
   SideBarProps
 >;

--- a/src/components/side-bar/side-bar.tsx
+++ b/src/components/side-bar/side-bar.tsx
@@ -1,12 +1,11 @@
 import React, {
   Children,
-  ComponentPropsWithoutRef,
   ReactElement,
   cloneElement,
   forwardRef,
   isValidElement,
-  useMemo,
 } from 'react';
+import type * as Polymoprphic from '@radix-ui/react-polymorphic';
 import cn from 'classnames';
 
 import { useBreakpoint } from '../../hooks';
@@ -18,7 +17,12 @@ export interface SideBarSectionProps extends AccordionItemProps {
   heading?: string;
 }
 
-export const SideBarSection = forwardRef<HTMLDivElement, SideBarSectionProps>(
+export type SideBarSectionComponent = Polymoprphic.ForwardRefComponent<
+  'div',
+  SideBarSectionProps
+>;
+
+export const SideBarSection: SideBarSectionComponent = forwardRef(
   function SideBarSection(
     { children, heading, className, isCollapsed = false, ...props },
     ref
@@ -44,7 +48,7 @@ export const SideBarSection = forwardRef<HTMLDivElement, SideBarSectionProps>(
   }
 );
 
-export interface SideBarProps extends ComponentPropsWithoutRef<'div'> {
+export interface SideBarProps {
   id: string;
   top?: ReactElement;
   children:
@@ -53,36 +57,37 @@ export interface SideBarProps extends ComponentPropsWithoutRef<'div'> {
     | Array<ReactElement<SideBarSectionProps> | null>;
 }
 
-export const SideBar = forwardRef<HTMLDivElement, SideBarProps>(
-  function SideBar({ id, top, children, className, ...props }, ref) {
-    const isDesktop = useBreakpoint('md');
-    const sidebarClasses = cn('mtfh-sidebar', className);
-    const renderChildren = useMemo(() => {
-      if (!isDesktop) {
-        return (
-          <Accordion id={id}>
-            {Children.map<
-              ReactElement<SideBarSectionProps> | undefined,
-              ReactElement<SideBarSectionProps> | null
-            >(children, (child) =>
-              child && isValidElement(child)
-                ? cloneElement(child, {
-                    isCollapsed: true,
-                  })
-                : undefined
-            )}
-          </Accordion>
-        );
-      }
+export type SideBarComponent = Polymoprphic.ForwardRefComponent<
+  'div',
+  SideBarProps
+>;
 
-      return <div id={id}>{children}</div>;
-    }, [isDesktop, children, id]);
+export const SideBar: SideBarComponent = forwardRef(function SideBar(
+  { as: SideBarComp = 'div', id, top, children, className, ...props },
+  ref
+) {
+  const isDesktop = useBreakpoint('md');
+  const sidebarClasses = cn('mtfh-sidebar', className);
 
-    return (
-      <div ref={ref} className={sidebarClasses} {...props}>
-        {top}
-        {renderChildren}
-      </div>
-    );
-  }
-);
+  return (
+    <SideBarComp ref={ref} className={sidebarClasses} {...props}>
+      {top}
+      {!isDesktop ? (
+        <Accordion id={id}>
+          {Children.map<
+            ReactElement<SideBarSectionProps> | undefined,
+            ReactElement<SideBarSectionProps> | null
+          >(children, (child) =>
+            child && isValidElement(child)
+              ? cloneElement(child, {
+                  isCollapsed: true,
+                })
+              : undefined
+          )}
+        </Accordion>
+      ) : (
+        <div id={id}>{children}</div>
+      )}
+    </SideBarComp>
+  );
+});

--- a/src/components/simple-pagination/__snapshots__/simple-pagination.test.tsx.snap
+++ b/src/components/simple-pagination/__snapshots__/simple-pagination.test.tsx.snap
@@ -5,9 +5,9 @@ exports[`it renders the nav with buttons 1`] = `
   <nav
     class="lbh-simple-pagination"
   >
-    <button
+    <a
       class="lbh-simple-pagination__link"
-      type="button"
+      href="/prev"
     >
       <svg
         fill="none"
@@ -21,10 +21,10 @@ exports[`it renders the nav with buttons 1`] = `
         />
       </svg>
       Prev
-    </button>
-    <button
+    </a>
+    <a
       class="lbh-simple-pagination__link lbh-simple-pagination__link--next"
-      type="button"
+      href="/next"
     >
       Next
       <svg
@@ -38,7 +38,7 @@ exports[`it renders the nav with buttons 1`] = `
           stroke-width="2"
         />
       </svg>
-    </button>
+    </a>
   </nav>
 </div>
 `;
@@ -48,9 +48,9 @@ exports[`it renders the nav with buttons and titles 1`] = `
   <nav
     class="lbh-simple-pagination"
   >
-    <button
+    <a
       class="lbh-simple-pagination__link"
-      type="button"
+      href="/prev"
     >
       <svg
         fill="none"
@@ -69,10 +69,10 @@ exports[`it renders the nav with buttons and titles 1`] = `
       >
         1 of 3
       </span>
-    </button>
-    <button
+    </a>
+    <a
       class="lbh-simple-pagination__link lbh-simple-pagination__link--next"
-      type="button"
+      href="/next"
     >
       Next
       <span
@@ -91,7 +91,7 @@ exports[`it renders the nav with buttons and titles 1`] = `
           stroke-width="2"
         />
       </svg>
-    </button>
+    </a>
   </nav>
 </div>
 `;

--- a/src/components/simple-pagination/simple-pagination.test.tsx
+++ b/src/components/simple-pagination/simple-pagination.test.tsx
@@ -7,8 +7,12 @@ import { SimplePagination, SimplePaginationButton } from './simple-pagination';
 test('it renders the nav with buttons', async () => {
   const { container } = render(
     <SimplePagination>
-      <SimplePaginationButton variant="previous">Prev</SimplePaginationButton>
-      <SimplePaginationButton variant="next">Next</SimplePaginationButton>
+      <SimplePaginationButton href="/prev" variant="previous">
+        Prev
+      </SimplePaginationButton>
+      <SimplePaginationButton href="/next" variant="next">
+        Next
+      </SimplePaginationButton>
     </SimplePagination>
   );
   expect(container).toMatchSnapshot();
@@ -18,10 +22,10 @@ test('it renders the nav with buttons', async () => {
 test('it renders the nav with buttons and titles', () => {
   const { container } = render(
     <SimplePagination>
-      <SimplePaginationButton variant="previous" title="1 of 3">
+      <SimplePaginationButton href="/prev" variant="previous" title="1 of 3">
         Prev
       </SimplePaginationButton>
-      <SimplePaginationButton variant="next" title="3 of 3">
+      <SimplePaginationButton href="/next" variant="next" title="3 of 3">
         Next
       </SimplePaginationButton>
     </SimplePagination>

--- a/src/components/simple-pagination/simple-pagination.tsx
+++ b/src/components/simple-pagination/simple-pagination.tsx
@@ -1,5 +1,5 @@
 import React, { ComponentPropsWithoutRef, forwardRef } from 'react';
-import type * as Polymoprphic from '@radix-ui/react-polymorphic';
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
 import cn from 'classnames';
 import './styles.scss';
 
@@ -21,7 +21,7 @@ export interface SimplePaginationButtonProps {
   variant: 'previous' | 'next';
 }
 
-export type SimplePaginationButtonComponent = Polymoprphic.ForwardRefComponent<
+export type SimplePaginationButtonComponent = Polymorphic.ForwardRefComponent<
   'a',
   SimplePaginationButtonProps
 >;

--- a/src/components/simple-pagination/simple-pagination.tsx
+++ b/src/components/simple-pagination/simple-pagination.tsx
@@ -1,4 +1,5 @@
 import React, { ComponentPropsWithoutRef, forwardRef } from 'react';
+import type * as Polymoprphic from '@radix-ui/react-polymorphic';
 import cn from 'classnames';
 import './styles.scss';
 
@@ -15,44 +16,52 @@ export const SimplePagination = forwardRef<
   );
 });
 
-export interface SimplePaginationButtonProps
-  extends ComponentPropsWithoutRef<'button'> {
+export interface SimplePaginationButtonProps {
   title?: string;
   variant: 'previous' | 'next';
 }
 
-export const SimplePaginationButton = forwardRef<
-  HTMLButtonElement,
+export type SimplePaginationButtonComponent = Polymoprphic.ForwardRefComponent<
+  'a',
   SimplePaginationButtonProps
->(function SimplePaginationButton(
-  { variant, className, title, children, ...props },
-  ref
-) {
-  return (
-    <button
-      type="button"
-      ref={ref}
-      className={cn(
-        'lbh-simple-pagination__link',
-        { 'lbh-simple-pagination__link--next': variant === 'next' },
-        className
-      )}
-      {...props}
-    >
-      {variant === 'previous' ? (
-        <svg width="11" height="19" viewBox="0 0 11 19" fill="none">
-          <path d="M10 1L2 9.5L10 18" strokeWidth="2" />
-        </svg>
-      ) : null}
-      {children}
-      {title ? (
-        <span className="lbh-simple-pagination__title">{title}</span>
-      ) : null}
-      {variant === 'next' ? (
-        <svg width="11" height="19" viewBox="0 0 11 19" fill="none">
-          <path d="M1 18L9 9.5L1 1" strokeWidth="2" />
-        </svg>
-      ) : null}
-    </button>
-  );
-});
+>;
+
+export const SimplePaginationButton: SimplePaginationButtonComponent =
+  forwardRef(function SimplePaginationButton(
+    {
+      as: SimplePaginationComp = 'a',
+      variant,
+      className,
+      title,
+      children,
+      ...props
+    },
+    ref
+  ) {
+    return (
+      <SimplePaginationComp
+        ref={ref}
+        className={cn(
+          'lbh-simple-pagination__link',
+          { 'lbh-simple-pagination__link--next': variant === 'next' },
+          className
+        )}
+        {...props}
+      >
+        {variant === 'previous' ? (
+          <svg width="11" height="19" viewBox="0 0 11 19" fill="none">
+            <path d="M10 1L2 9.5L10 18" strokeWidth="2" />
+          </svg>
+        ) : null}
+        {children}
+        {title ? (
+          <span className="lbh-simple-pagination__title">{title}</span>
+        ) : null}
+        {variant === 'next' ? (
+          <svg width="11" height="19" viewBox="0 0 11 19" fill="none">
+            <path d="M1 18L9 9.5L1 1" strokeWidth="2" />
+          </svg>
+        ) : null}
+      </SimplePaginationComp>
+    );
+  });

--- a/src/components/text-area/text-area.tsx
+++ b/src/components/text-area/text-area.tsx
@@ -8,12 +8,14 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 
-import { pluralize } from '../../utils';
+import { pluralize, widthOverrides } from '../../utils';
+
 import './styles.scss';
 
 export interface TextAreaProps extends ComponentPropsWithoutRef<'textarea'> {
   maxLength?: number;
   error?: boolean;
+  override?: number;
 }
 
 const getLengthOfValue = (
@@ -29,7 +31,10 @@ const getLengthOfValue = (
 };
 
 export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
-  function TextArea({ maxLength, error, className, onChange, ...props }, ref) {
+  function TextArea(
+    { maxLength, error, className, onChange, override, ...props },
+    ref
+  ) {
     const { value, defaultValue } = props;
     const isControlled = value !== undefined;
     const initialValue = value || defaultValue;
@@ -67,6 +72,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
       'lbh-textarea',
       { 'govuk-textarea--error': error },
       'lbh-character-count',
+      widthOverrides(override),
       className
     );
 
@@ -75,7 +81,8 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
       'govuk-character-count__message',
       {
         'govuk-error-message': exceedingValue !== false && exceedingValue < 0,
-      }
+      },
+      widthOverrides(override)
     );
 
     return (

--- a/src/types/lbh-frontend.d.ts
+++ b/src/types/lbh-frontend.d.ts
@@ -1,33 +1,33 @@
 /* eslint-disable max-classes-per-file */
 declare module 'lbh-frontend' {
   export class Accordion {
-    constructor(module: HTMLDivElement);
+    constructor(module: HTMLElement);
 
     init(): void;
 
-    setExpanded(expanded: boolean, section: HTMLDivElement | null): void;
+    setExpanded(expanded: boolean, section: HTMLElement | null): void;
 
-    isExpanded(section: HTMLDivElement | null): boolean;
+    isExpanded(section: HTMLElement | null): boolean;
 
-    $sections: NodeListOf<HTMLDivElement>;
+    $sections: NodeListOf<HTMLElement>;
 
     sectionButtonClass: string;
   }
 
   export class ErrorSummary {
-    constructor(module: HTMLDivElement);
+    constructor(module: HTMLElement);
 
     init(): void;
   }
 
   export class Radios {
-    constructor(module: HTMLDivElement);
+    constructor(module: HTMLElement);
 
     init(): void;
   }
 
   export class Checkboxes {
-    constructor(module: HTMLDivElement);
+    constructor(module: HTMLElement);
 
     init(): void;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1287,6 +1287,11 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
   integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
 
+"@radix-ui/react-polymorphic@^0.0.12":
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-polymorphic/-/react-polymorphic-0.0.12.tgz#bf4ae516669b68e059549538104d97322f7c876b"
+  integrity sha512-/GYNMicBnGzjD1d2fCAuzql1VeFrp8mqM3xfzT1kxhnV85TKdURO45jBfMgqo17XNXoNhWIAProUsCO4qFAAIg==
+
 "@reach/dialog@^0.15.0":
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/@reach/dialog/-/dialog-0.15.0.tgz#e1dd2d30ea060a65fc8810b9a7e16f1a5bc64d69"


### PR DESCRIPTION
- Make relevant components polymorphic
- Remove back button from Layout component
- Add override (width) to relevant components

Example usage of Polymorphic Components
```tsx
import { Link as RouterLink } from 'react-router-dom';
<Button as="a" href="/">Button Link</Button>
<Link as={RouterLink} to="/">Router Link</Link>
```

Deprecation:
ButtonLink, LinkButton to be removed in favour of Polymorphic Button and Link components.

Actions:
Update MFEs to remove usage of deprecated components and then remove from common.
Update MFE's Layout usage to include back button in `top` prop.