### PR TITLE
feat(api): extract etag from get requests and append if-match on patch

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,21 +1,43 @@
-import axios, { AxiosError, CancelTokenSource } from 'axios';
+import axios, {
+  AxiosError,
+  AxiosRequestConfig,
+  CancelTokenSource,
+} from 'axios';
 
 import { $auth, logout } from '../auth';
+
+interface Config extends AxiosRequestConfig {
+  headers: Record<string, string>;
+}
 
 const axiosInstance = axios.create({
   responseType: 'json',
 });
 
-axiosInstance.interceptors.request.use((config) => ({
-  ...config,
-  headers: {
-    ...(config.headers as Headers),
-    Authorization: `Bearer ${$auth.getValue().token}`,
-  },
-}));
+axiosInstance.interceptors.request.use((config) => {
+  const req: Config = {
+    ...config,
+    headers: {
+      ...config.headers,
+      Authorization: `Bearer ${$auth.getValue().token}`,
+    },
+  };
+
+  if (req.method === 'patch' && Object.keys(req.data).includes('etag')) {
+    req.headers['If-Match'] = req.data.etag;
+    delete req.data.etag;
+  }
+
+  return req;
+});
 
 axiosInstance.interceptors.response.use(
-  (res) => res,
+  (res) => {
+    if (res.config.method === 'get' && res.data?.id) {
+      res.data.etag = res.headers.etag;
+    }
+    return res;
+  },
   (error: AxiosError) => {
     if (error.response?.status === 403) {
       logout();

--- a/src/components/button/__snapshots__/button.test.tsx.snap
+++ b/src/components/button/__snapshots__/button.test.tsx.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`it can render as a link 1`] = `
+<div>
+  <a
+    class="govuk-button lbh-button"
+    href="/"
+  >
+    Test Link
+  </a>
+</div>
+`;
+
 exports[`it renders correctly 1`] = `
 <div>
   <button
@@ -14,7 +25,7 @@ exports[`it renders correctly 1`] = `
 exports[`it renders the correct variant 1`] = `
 <div>
   <button
-    class="govuk-button lbh-button govuk-secondary lbh-button--secondary"
+    class="govuk-button lbh-button govuk-button--secondary lbh-button--secondary"
     type="button"
   >
     Test Link

--- a/src/components/button/button.test.tsx
+++ b/src/components/button/button.test.tsx
@@ -31,6 +31,16 @@ test('it renders the correct variant', async () => {
   await testA11y(container);
 });
 
+test('it can render as a link', async () => {
+  const { container } = render(
+    <Button as="a" href="/">
+      Test Link
+    </Button>
+  );
+  expect(container).toMatchSnapshot();
+  await testA11y(container);
+});
+
 test('it accepts a ref', () => {
   const callback = jest.fn();
   const Comp = () => {

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -36,7 +36,7 @@ export const Button: ButtonComponent = forwardRef(function Button(
     'govuk-button',
     'lbh-button',
     {
-      'govuk-secondary lbh-button--secondary': variant === 'secondary',
+      'govuk-button--secondary lbh-button--secondary': variant === 'secondary',
       'lbh-button--disabled govuk-button--disabled': isDisabled,
     },
     widthOverrides(override),

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -75,7 +75,7 @@ export const getSuccess = (data: unknown, url = ''): void => {
   server.use(
     rest.get(`/api/${url}`, (req, res, ctx) => {
       if (req.headers?.has('Authorization')) {
-        return res.once(ctx.status(200), ctx.json(data));
+        return res.once(ctx.status(200), ctx.set('Etag', '1'), ctx.json(data));
       }
       return res.once(
         ctx.status(403),


### PR DESCRIPTION
Axios res interceptor will now extract the `Etag` header and append it to the response data `{ etag: '12' }`.
Axios req interceptor will now extract the `etag` data param and append it to the `If-Match` header.