### PR TITLE
fix(useErrorCodes): exporting useErrorCodes hook

### DIFF
--- a/lib/api/comments/v1/service.ts
+++ b/lib/api/comments/v1/service.ts
@@ -1,7 +1,7 @@
 import { stringify } from "query-string";
 
 import { config } from "@mtfh/common/lib/config";
-import { AxiosSWRInfiniteResponse, useAxiosSWRInfinite } from "@mtfh/common/lib/hooks";
+import { AxiosSWRInfiniteResponse, useAxiosSWRInfinite } from "@mtfh/common/lib/http";
 import { Comment } from "./types";
 
 export interface GetCommentsByTargetIdResponse {

--- a/lib/api/comments/v2/services.ts
+++ b/lib/api/comments/v2/services.ts
@@ -5,7 +5,7 @@ import {
   AxiosSWRInfiniteConfiguration,
   AxiosSWRInfiniteResponse,
   useAxiosSWRInfinite,
-} from "@mtfh/common/lib/hooks";
+} from "@mtfh/common/lib/http";
 import type { Comment } from "./types";
 
 export interface CommentsResponse {

--- a/lib/api/contact-details/v1/service.ts
+++ b/lib/api/contact-details/v1/service.ts
@@ -2,9 +2,9 @@ import { config } from "@mtfh/common/lib/config";
 import {
   AxiosSWRConfiguration,
   AxiosSWRResponse,
+  axiosInstance,
   useAxiosSWR,
-} from "@mtfh/common/lib/hooks";
-import { axiosInstance } from "@mtfh/common/lib/http";
+} from "@mtfh/common/lib/http";
 import { removeWhitespace } from "@mtfh/common/lib/utils";
 import {
   ContactDetail,

--- a/lib/api/person/v1/service.ts
+++ b/lib/api/person/v1/service.ts
@@ -2,10 +2,11 @@ import { config } from "@mtfh/common/lib/config";
 import {
   AxiosSWRConfiguration,
   AxiosSWRResponse,
+  axiosInstance,
   mutate,
   useAxiosSWR,
-} from "@mtfh/common/lib/hooks";
-import { axiosInstance } from "@mtfh/common/lib/http";
+} from "@mtfh/common/lib/http";
+
 import { Person, TenureSummary } from "./types";
 
 export const usePerson = (

--- a/lib/api/person/v2/service.ts
+++ b/lib/api/person/v2/service.ts
@@ -1,6 +1,6 @@
 import { config } from "@mtfh/common/lib/config";
-import { mutate } from "@mtfh/common/lib/hooks";
-import { axiosInstance } from "@mtfh/common/lib/http";
+import { axiosInstance, mutate } from "@mtfh/common/lib/http";
+
 import { Person } from "./types";
 
 export interface PostPersonRequestData extends Omit<Person, "id" | "tenures"> {

--- a/lib/api/property/v1/service.ts
+++ b/lib/api/property/v1/service.ts
@@ -3,7 +3,7 @@ import {
   AxiosSWRConfiguration,
   AxiosSWRResponse,
   useAxiosSWR,
-} from "@mtfh/common/lib/hooks";
+} from "@mtfh/common/lib/http";
 import { Property } from "./types";
 
 export function useProperty(

--- a/lib/api/reference-data/v1/service.ts
+++ b/lib/api/reference-data/v1/service.ts
@@ -3,7 +3,7 @@ import {
   AxiosSWRConfiguration,
   AxiosSWRResponse,
   useAxiosSWR,
-} from "@mtfh/common/lib/hooks";
+} from "@mtfh/common/lib/http";
 import { ReferenceData } from "./types";
 
 type ReferenceDataResponse<T extends string> = { [key in T]: ReferenceData[] };

--- a/lib/api/tenure/v1/service.ts
+++ b/lib/api/tenure/v1/service.ts
@@ -2,10 +2,11 @@ import { config } from "@mtfh/common/lib/config";
 import {
   AxiosSWRConfiguration,
   AxiosSWRResponse,
+  axiosInstance,
   mutate,
   useAxiosSWR,
-} from "@mtfh/common/lib/hooks";
-import { axiosInstance } from "@mtfh/common/lib/http";
+} from "@mtfh/common/lib/http";
+
 import { HouseholdMember, Tenure, TenureAsset, TenureType } from "./types";
 
 export const useTenure = (

--- a/lib/hooks/index.ts
+++ b/lib/hooks/index.ts
@@ -1,4 +1,3 @@
-export * from "./use-axios-swr";
 export * from "./use-breakpoint";
 export * from "./use-error-codes";
 export * from "./use-feature-toggle";

--- a/lib/hooks/index.ts
+++ b/lib/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from "./use-axios-swr";
 export * from "./use-breakpoint";
+export * from "./use-error-codes";
 export * from "./use-feature-toggle";

--- a/lib/http/index.ts
+++ b/lib/http/index.ts
@@ -1,1 +1,2 @@
 export * from "./http";
+export * from "./use-axios-swr";

--- a/lib/http/use-axios-swr.test.ts
+++ b/lib/http/use-axios-swr.test.ts
@@ -1,7 +1,7 @@
 import { request } from "@hackney/mtfh-test-utils";
 import { act, renderHook } from "@testing-library/react-hooks";
 
-import { useAxiosSWR, useAxiosSWRInfinite } from "../use-axios-swr";
+import { useAxiosSWR, useAxiosSWRInfinite } from "./use-axios-swr";
 
 describe("useAxiosSWR", () => {
   test("it configures useSWR correctly", async () => {

--- a/lib/http/use-axios-swr.ts
+++ b/lib/http/use-axios-swr.ts
@@ -6,7 +6,7 @@ import useSWRInfinite, {
   SWRInfiniteResponse,
 } from "swr/infinite";
 
-import { axiosInstance } from "@mtfh/common/lib/http";
+import { axiosInstance } from "./http";
 
 export type AxiosSWRError = AxiosError;
 export type AxiosSWRResponse<T> = SWRResponse<T, AxiosSWRError>;


### PR DESCRIPTION
Added missing export in `index.ts` under hooks directory for `useErrorCodes`