### PR TITLE
MR-692 - Add getAddressViaUprn call for Addresses API V1 endpoint

### DIFF
--- a/lib/api/address/v1/service.test.ts
+++ b/lib/api/address/v1/service.test.ts
@@ -1,0 +1,50 @@
+import { config } from "@mtfh/common/lib/config";
+import {
+    axiosInstance, AxiosSWRConfiguration, useAxiosSWR
+} from "@mtfh/common/lib/http";
+import { AddressAPIResponse, getAddressViaUprn, searchAddress, useAddressLookup } from "./service";
+import { Address } from "./types";
+
+jest.mock("@mtfh/common/lib/http", () => ({
+    ...jest.requireActual("@mtfh/common/lib/http"),
+    axiosInstance: { get: jest.fn() },
+    useAxiosSWR: jest.fn(),
+    mutate: jest.fn(),
+}));
+
+test("searchAddress: the API is called with the right parameters", async () => {
+    const postcode: string = "FK81FH"
+
+    searchAddress(postcode);
+
+    expect(axiosInstance.get).toBeCalledWith(
+        `${config.addressApiUrlV1}/addresses?postcode=${postcode}`, { "headers": { "skip-x-correlation-id": true } }
+    );
+});
+
+test("getAddressViaUprn: the API is called with the right parameters", async () => {
+    const uprn: string = "0123456789"
+
+    getAddressViaUprn(uprn);
+
+    expect(axiosInstance.get).toBeCalledWith(
+        `${config.addressApiUrlV1}/addresses?uprn=${uprn}`, { "headers": { "skip-x-correlation-id": true } }
+    );
+});
+
+test("useAddressLookup: the API is called with the right parameters", async () => {
+    const returnedValue: Address = { line1: "35 Weir Street", line2: "", line3: "", line4: "", town: "Stirling", postcode: "FK81FH", UPRN: 1234 };
+    const postcode = "FK81FH";
+    const options: AxiosSWRConfiguration<AddressAPIResponse> = {
+        timeout: 5000,
+        headers: {
+            "skip-x-correlation-id": true,
+        },
+    };
+
+    (useAxiosSWR as jest.Mock).mockResolvedValueOnce(returnedValue);
+
+    const response = await useAddressLookup(postcode, options);
+    expect(useAxiosSWR).toBeCalledWith(`${config.addressApiUrlV1}/addresses?postcode=${postcode}`, options);
+    expect(response).toBe(returnedValue);
+});

--- a/lib/api/address/v1/service.test.ts
+++ b/lib/api/address/v1/service.test.ts
@@ -1,50 +1,67 @@
 import { config } from "@mtfh/common/lib/config";
+import { AxiosSWRConfiguration, axiosInstance, useAxiosSWR } from "@mtfh/common/lib/http";
+
 import {
-    axiosInstance, AxiosSWRConfiguration, useAxiosSWR
-} from "@mtfh/common/lib/http";
-import { AddressAPIResponse, getAddressViaUprn, searchAddress, useAddressLookup } from "./service";
+  AddressAPIResponse,
+  getAddressViaUprn,
+  searchAddress,
+  useAddressLookup,
+} from "./service";
 import { Address } from "./types";
 
 jest.mock("@mtfh/common/lib/http", () => ({
-    ...jest.requireActual("@mtfh/common/lib/http"),
-    axiosInstance: { get: jest.fn() },
-    useAxiosSWR: jest.fn(),
-    mutate: jest.fn(),
+  ...jest.requireActual("@mtfh/common/lib/http"),
+  axiosInstance: { get: jest.fn() },
+  useAxiosSWR: jest.fn(),
+  mutate: jest.fn(),
 }));
 
 test("searchAddress: the API is called with the right parameters", async () => {
-    const postcode: string = "FK81FH"
+  const postcode = "FK81FH";
 
-    searchAddress(postcode);
+  searchAddress(postcode);
 
-    expect(axiosInstance.get).toBeCalledWith(
-        `${config.addressApiUrlV1}/addresses?postcode=${postcode}`, { "headers": { "skip-x-correlation-id": true } }
-    );
+  expect(axiosInstance.get).toBeCalledWith(
+    `${config.addressApiUrlV1}/addresses?postcode=${postcode}`,
+    { headers: { "skip-x-correlation-id": true } },
+  );
 });
 
 test("getAddressViaUprn: the API is called with the right parameters", async () => {
-    const uprn: string = "0123456789"
+  const uprn = "0123456789";
 
-    getAddressViaUprn(uprn);
+  getAddressViaUprn(uprn);
 
-    expect(axiosInstance.get).toBeCalledWith(
-        `${config.addressApiUrlV1}/addresses?uprn=${uprn}`, { "headers": { "skip-x-correlation-id": true } }
-    );
+  expect(axiosInstance.get).toBeCalledWith(
+    `${config.addressApiUrlV1}/addresses?uprn=${uprn}`,
+    { headers: { "skip-x-correlation-id": true } },
+  );
 });
 
 test("useAddressLookup: the API is called with the right parameters", async () => {
-    const returnedValue: Address = { line1: "35 Weir Street", line2: "", line3: "", line4: "", town: "Stirling", postcode: "FK81FH", UPRN: 1234 };
-    const postcode = "FK81FH";
-    const options: AxiosSWRConfiguration<AddressAPIResponse> = {
-        timeout: 5000,
-        headers: {
-            "skip-x-correlation-id": true,
-        },
-    };
+  const returnedValue: Address = {
+    line1: "35 Weir Street",
+    line2: "",
+    line3: "",
+    line4: "",
+    town: "Stirling",
+    postcode: "FK81FH",
+    UPRN: 1234,
+  };
+  const postcode = "FK81FH";
+  const options: AxiosSWRConfiguration<AddressAPIResponse> = {
+    timeout: 5000,
+    headers: {
+      "skip-x-correlation-id": true,
+    },
+  };
 
-    (useAxiosSWR as jest.Mock).mockResolvedValueOnce(returnedValue);
+  (useAxiosSWR as jest.Mock).mockResolvedValueOnce(returnedValue);
 
-    const response = await useAddressLookup(postcode, options);
-    expect(useAxiosSWR).toBeCalledWith(`${config.addressApiUrlV1}/addresses?postcode=${postcode}`, options);
-    expect(response).toBe(returnedValue);
+  const response = await useAddressLookup(postcode, options);
+  expect(useAxiosSWR).toBeCalledWith(
+    `${config.addressApiUrlV1}/addresses?postcode=${postcode}`,
+    options,
+  );
+  expect(response).toBe(returnedValue);
 });

--- a/lib/api/address/v1/service.ts
+++ b/lib/api/address/v1/service.ts
@@ -13,7 +13,7 @@ interface SearchAddressResponse {
 }
 
 export const searchAddress = async (postCode: string): Promise<SearchAddressResponse> =>
-  await axiosInstance
+  axiosInstance
     .get<AddressAPIResponse>(`${config.addressApiUrlV1}/addresses?postcode=${postCode}`, {
       headers: {
         "skip-x-correlation-id": true,
@@ -28,7 +28,7 @@ export const searchAddress = async (postCode: string): Promise<SearchAddressResp
     });
 
 export const getAddressViaUprn = async (UPRN: string): Promise<SearchAddressResponse> =>
-  await axiosInstance
+  axiosInstance
     .get<AddressAPIResponse>(`${config.addressApiUrlV1}/addresses?uprn=${UPRN}`, {
       headers: {
         "skip-x-correlation-id": true,

--- a/lib/api/address/v1/service.ts
+++ b/lib/api/address/v1/service.ts
@@ -7,14 +7,29 @@ interface AddressAPIResponse {
   data: { address: Address[] };
 }
 
-interface SearchAddressRespone {
+interface SearchAddressResponse {
   addresses?: Address[];
   error?: { code: number };
 }
 
-export const searchAddress = (postCode: string): Promise<SearchAddressRespone> =>
+export const searchAddress = (postCode: string): Promise<SearchAddressResponse> =>
   axiosInstance
     .get<AddressAPIResponse>(`${config.addressApiUrlV1}/addresses?postcode=${postCode}`, {
+      headers: {
+        "skip-x-correlation-id": true,
+      },
+    })
+    .then((res) => ({ addresses: res.data.data.address }))
+    .catch((res) => {
+      if (res.message.toLowerCase().indexOf("network") !== -1) {
+        return { error: { code: 500 } };
+      }
+      return res;
+    });
+
+export const getAddressViaUprn = (UPRN: string): Promise<SearchAddressResponse> =>
+  axiosInstance
+    .get<AddressAPIResponse>(`${config.addressApiUrlV1}/addresses?uprn=${UPRN}`, {
       headers: {
         "skip-x-correlation-id": true,
       },

--- a/lib/api/address/v1/service.ts
+++ b/lib/api/address/v1/service.ts
@@ -3,7 +3,7 @@ import { AxiosSWRConfiguration, axiosInstance, useAxiosSWR } from "@mtfh/common/
 
 import type { Address } from "./types";
 
-interface AddressAPIResponse {
+export interface AddressAPIResponse {
   data: { address: Address[] };
 }
 
@@ -12,8 +12,8 @@ interface SearchAddressResponse {
   error?: { code: number };
 }
 
-export const searchAddress = (postCode: string): Promise<SearchAddressResponse> =>
-  axiosInstance
+export const searchAddress = async (postCode: string): Promise<SearchAddressResponse> =>
+  await axiosInstance
     .get<AddressAPIResponse>(`${config.addressApiUrlV1}/addresses?postcode=${postCode}`, {
       headers: {
         "skip-x-correlation-id": true,
@@ -27,8 +27,8 @@ export const searchAddress = (postCode: string): Promise<SearchAddressResponse> 
       return res;
     });
 
-export const getAddressViaUprn = (UPRN: string): Promise<SearchAddressResponse> =>
-  axiosInstance
+export const getAddressViaUprn = async (UPRN: string): Promise<SearchAddressResponse> =>
+  await axiosInstance
     .get<AddressAPIResponse>(`${config.addressApiUrlV1}/addresses?uprn=${UPRN}`, {
       headers: {
         "skip-x-correlation-id": true,


### PR DESCRIPTION
After discussing this we've decided that to retrieve an address via UPRN, we're going to be using the V1 endpoint in SearchAddressController. We have this working in Postman, however the existing service file does not have a call to allow an address to be retrieved via the UPRN (unlike the service in api\address\v2).

I've copied the call from api\address\v2\service, and amended it slightly.

Also corrected spelling mistake in interface name SearchAddressResponse.