### PR TITLE
MR-692 - Add PatchAsset API call for use in mtfh-frontend-property

### DIFF
--- a/lib/api/asset/v1/service.test.ts
+++ b/lib/api/asset/v1/service.test.ts
@@ -1,0 +1,90 @@
+import { config } from "@mtfh/common/lib/config";
+
+import { AxiosSWRConfiguration, axiosInstance, useAxiosSWR } from "@mtfh/common/lib/http";
+import { patchAsset, useAsset } from "./service";
+import { Asset, AssetAddress, AssetLocation } from "./types";
+
+jest.mock("@mtfh/common/lib/http", () => ({
+    ...jest.requireActual("@mtfh/common/lib/http"),
+    axiosInstance: { patch: jest.fn() },
+    useAxiosSWR: jest.fn(),
+    mutate: jest.fn(),
+}));
+
+test("patchAsset: the API is called with the right parameters", async () => {
+    const assetGuid: string = "15adc44b-6fde-46e8-af9c-e18b1495c9ab";
+    const assetVersion: string = "3"
+    const assetAddress: AssetAddress = {
+        uprn: "100021045676",
+        addressLine1: "FLAT B",
+        addressLine2: "51 GREENWOOD ROAD",
+        addressLine3: "HACKNEY",
+        addressLine4: "LONDON",
+        postCode: "E8 1NT",
+        postPreamble: ""
+    }
+
+    patchAsset(assetGuid, assetAddress, assetVersion);
+
+    expect(axiosInstance.patch).toBeCalledWith(
+        `${config.assetApiUrlV1}/assets/${assetGuid}/address`, assetAddress,
+        { headers: { "If-Match": assetVersion } },
+    );
+});
+
+test("useAsset: the API is called with the right parameters", async () => {
+    const returnedValue: Asset = {
+        id: "15adc44b-6fde-46e8-af9c-e18b1495c9ab",
+        assetId: "100021045676",
+        assetType: "LettableNonDwelling",
+        rootAsset: "",
+        parentAssetIds: "",
+        assetLocation: { floorNo: 4, totalBlockFloors: 6, parentAssets: [{ id: "123", name: "asset", type: "asset-type" }] },
+        assetAddress: {
+            uprn: "100021045676",
+            addressLine1: "FLAT B",
+            addressLine2: "51 GREENWOOD ROAD",
+            addressLine3: "HACKNEY",
+            addressLine4: "LONDON",
+            postCode: "E8 1NT",
+            postPreamble: ""
+        },
+        assetManagement: {
+            agent: "agent",
+            areaOfficeName: "areaOfficeName",
+            isCouncilProperty: true,
+            managingOrganisation: "org",
+            managingOrganisationId: "456",
+            owner: "owner",
+            isTMOManaged: true
+        },
+        assetCharacteristics: {
+            numberOfBedrooms: 2,
+            numberOfLifts: 1,
+            numberOfLivingRooms: 1,
+            windowType: "DBL",
+            yearConstructed: "2077"
+        },
+        tenure: null,
+        versionNumber: 2,
+        patches: [
+            {
+                id: "bd0a8e2b-c3b5-4628-aa33-8e7509d5eac6",
+                parentId: "8d4fb05d-3ff5-48b7-a17a-71fcb27a66a8",
+                name: "SN4",
+                patchType: "patch",
+                domain: "MMH",
+                responsibleEntities: [],
+            }
+        ]
+    }
+    const assetGuid: string = "15adc44b-6fde-46e8-af9c-e18b1495c9ab";
+
+    (useAxiosSWR as jest.Mock).mockResolvedValueOnce(returnedValue);
+
+    const response = await useAsset(assetGuid, undefined);
+    expect(useAxiosSWR).toBeCalledWith(
+        `${config.assetApiUrlV1}/assets/${assetGuid}`, undefined
+    );
+    expect(response).toBe(returnedValue);
+});

--- a/lib/api/asset/v1/service.test.ts
+++ b/lib/api/asset/v1/service.test.ts
@@ -1,90 +1,96 @@
 import { config } from "@mtfh/common/lib/config";
+import { axiosInstance, useAxiosSWR } from "@mtfh/common/lib/http";
 
-import { AxiosSWRConfiguration, axiosInstance, useAxiosSWR } from "@mtfh/common/lib/http";
 import { patchAsset, useAsset } from "./service";
-import { Asset, AssetAddress, AssetLocation } from "./types";
+import { Asset, AssetAddress } from "./types";
 
 jest.mock("@mtfh/common/lib/http", () => ({
-    ...jest.requireActual("@mtfh/common/lib/http"),
-    axiosInstance: { patch: jest.fn() },
-    useAxiosSWR: jest.fn(),
-    mutate: jest.fn(),
+  ...jest.requireActual("@mtfh/common/lib/http"),
+  axiosInstance: { patch: jest.fn() },
+  useAxiosSWR: jest.fn(),
+  mutate: jest.fn(),
 }));
 
 test("patchAsset: the API is called with the right parameters", async () => {
-    const assetGuid: string = "15adc44b-6fde-46e8-af9c-e18b1495c9ab";
-    const assetVersion: string = "3"
-    const assetAddress: AssetAddress = {
-        uprn: "100021045676",
-        addressLine1: "FLAT B",
-        addressLine2: "51 GREENWOOD ROAD",
-        addressLine3: "HACKNEY",
-        addressLine4: "LONDON",
-        postCode: "E8 1NT",
-        postPreamble: ""
-    }
+  const assetGuid = "15adc44b-6fde-46e8-af9c-e18b1495c9ab";
+  const assetVersion = "3";
+  const assetAddress: AssetAddress = {
+    uprn: "100021045676",
+    addressLine1: "FLAT B",
+    addressLine2: "51 GREENWOOD ROAD",
+    addressLine3: "HACKNEY",
+    addressLine4: "LONDON",
+    postCode: "E8 1NT",
+    postPreamble: "",
+  };
 
-    patchAsset(assetGuid, assetAddress, assetVersion);
+  patchAsset(assetGuid, assetAddress, assetVersion);
 
-    expect(axiosInstance.patch).toBeCalledWith(
-        `${config.assetApiUrlV1}/assets/${assetGuid}/address`, assetAddress,
-        { headers: { "If-Match": assetVersion } },
-    );
+  expect(axiosInstance.patch).toBeCalledWith(
+    `${config.assetApiUrlV1}/assets/${assetGuid}/address`,
+    assetAddress,
+    { headers: { "If-Match": assetVersion } },
+  );
 });
 
 test("useAsset: the API is called with the right parameters", async () => {
-    const returnedValue: Asset = {
-        id: "15adc44b-6fde-46e8-af9c-e18b1495c9ab",
-        assetId: "100021045676",
-        assetType: "LettableNonDwelling",
-        rootAsset: "",
-        parentAssetIds: "",
-        assetLocation: { floorNo: 4, totalBlockFloors: 6, parentAssets: [{ id: "123", name: "asset", type: "asset-type" }] },
-        assetAddress: {
-            uprn: "100021045676",
-            addressLine1: "FLAT B",
-            addressLine2: "51 GREENWOOD ROAD",
-            addressLine3: "HACKNEY",
-            addressLine4: "LONDON",
-            postCode: "E8 1NT",
-            postPreamble: ""
-        },
-        assetManagement: {
-            agent: "agent",
-            areaOfficeName: "areaOfficeName",
-            isCouncilProperty: true,
-            managingOrganisation: "org",
-            managingOrganisationId: "456",
-            owner: "owner",
-            isTMOManaged: true
-        },
-        assetCharacteristics: {
-            numberOfBedrooms: 2,
-            numberOfLifts: 1,
-            numberOfLivingRooms: 1,
-            windowType: "DBL",
-            yearConstructed: "2077"
-        },
-        tenure: null,
-        versionNumber: 2,
-        patches: [
-            {
-                id: "bd0a8e2b-c3b5-4628-aa33-8e7509d5eac6",
-                parentId: "8d4fb05d-3ff5-48b7-a17a-71fcb27a66a8",
-                name: "SN4",
-                patchType: "patch",
-                domain: "MMH",
-                responsibleEntities: [],
-            }
-        ]
-    }
-    const assetGuid: string = "15adc44b-6fde-46e8-af9c-e18b1495c9ab";
+  const returnedValue: Asset = {
+    id: "15adc44b-6fde-46e8-af9c-e18b1495c9ab",
+    assetId: "100021045676",
+    assetType: "LettableNonDwelling",
+    rootAsset: "",
+    parentAssetIds: "",
+    assetLocation: {
+      floorNo: 4,
+      totalBlockFloors: 6,
+      parentAssets: [{ id: "123", name: "asset", type: "asset-type" }],
+    },
+    assetAddress: {
+      uprn: "100021045676",
+      addressLine1: "FLAT B",
+      addressLine2: "51 GREENWOOD ROAD",
+      addressLine3: "HACKNEY",
+      addressLine4: "LONDON",
+      postCode: "E8 1NT",
+      postPreamble: "",
+    },
+    assetManagement: {
+      agent: "agent",
+      areaOfficeName: "areaOfficeName",
+      isCouncilProperty: true,
+      managingOrganisation: "org",
+      managingOrganisationId: "456",
+      owner: "owner",
+      isTMOManaged: true,
+    },
+    assetCharacteristics: {
+      numberOfBedrooms: 2,
+      numberOfLifts: 1,
+      numberOfLivingRooms: 1,
+      windowType: "DBL",
+      yearConstructed: "2077",
+    },
+    tenure: null,
+    versionNumber: 2,
+    patches: [
+      {
+        id: "bd0a8e2b-c3b5-4628-aa33-8e7509d5eac6",
+        parentId: "8d4fb05d-3ff5-48b7-a17a-71fcb27a66a8",
+        name: "SN4",
+        patchType: "patch",
+        domain: "MMH",
+        responsibleEntities: [],
+      },
+    ],
+  };
+  const assetGuid = "15adc44b-6fde-46e8-af9c-e18b1495c9ab";
 
-    (useAxiosSWR as jest.Mock).mockResolvedValueOnce(returnedValue);
+  (useAxiosSWR as jest.Mock).mockResolvedValueOnce(returnedValue);
 
-    const response = await useAsset(assetGuid, undefined);
-    expect(useAxiosSWR).toBeCalledWith(
-        `${config.assetApiUrlV1}/assets/${assetGuid}`, undefined
-    );
-    expect(response).toBe(returnedValue);
+  const response = await useAsset(assetGuid, undefined);
+  expect(useAxiosSWR).toBeCalledWith(
+    `${config.assetApiUrlV1}/assets/${assetGuid}`,
+    undefined,
+  );
+  expect(response).toBe(returnedValue);
 });

--- a/lib/api/asset/v1/service.ts
+++ b/lib/api/asset/v1/service.ts
@@ -1,8 +1,8 @@
 import { config } from "@mtfh/common/lib/config";
 import {
-  axiosInstance,
   AxiosSWRConfiguration,
   AxiosSWRResponse,
+  axiosInstance,
   useAxiosSWR,
 } from "@mtfh/common/lib/http";
 
@@ -15,13 +15,16 @@ export const useAsset = (
   return useAxiosSWR(id && `${config.assetApiUrlV1}/assets/${id}`, options);
 };
 
-export const patchAsset = async (id: string, assetAddress: AssetAddress, assetVersion: string): Promise<void> => {
-  await axiosInstance.patch(
-    `${config.assetApiUrlV1}/assets/${id}/address`,
-    assetAddress, {
+export const patchAsset = async (
+  id: string,
+  assetAddress: AssetAddress,
+  assetVersion: string,
+): Promise<void> => {
+  await axiosInstance
+    .patch(`${config.assetApiUrlV1}/assets/${id}/address`, assetAddress, {
       headers: {
         "If-Match": assetVersion,
       },
-    }
-  ).catch(error => error);
+    })
+    .catch((error) => error);
 };

--- a/lib/api/asset/v1/service.ts
+++ b/lib/api/asset/v1/service.ts
@@ -1,15 +1,27 @@
 import { config } from "@mtfh/common/lib/config";
 import {
+  axiosInstance,
   AxiosSWRConfiguration,
   AxiosSWRResponse,
   useAxiosSWR,
 } from "@mtfh/common/lib/http";
 
-import { Asset } from "./types";
+import { Asset, AssetAddress } from "./types";
 
 export const useAsset = (
   id: string | null,
   options?: AxiosSWRConfiguration<Asset>,
 ): AxiosSWRResponse<Asset> => {
   return useAxiosSWR(id && `${config.assetApiUrlV1}/assets/${id}`, options);
+};
+
+export const patchAsset = async (id: string, assetAddress: AssetAddress, assetVersion: string): Promise<void> => {
+  await axiosInstance.patch(
+    `${config.assetApiUrlV1}/assets/${id}/address`,
+    assetAddress, {
+      headers: {
+        "If-Match": assetVersion,
+      },
+    }
+  ).catch(error => error);
 };

--- a/lib/api/asset/v1/types.ts
+++ b/lib/api/asset/v1/types.ts
@@ -14,15 +14,16 @@ export interface Asset {
   rootAsset: string;
   parentAssetIds: string;
   patches?: Patch[];
+  versionNumber?: number
 }
 
-interface AssetLocation {
+export interface AssetLocation {
   floorNo: number;
   totalBlockFloors: number;
   parentAssets: Assets[];
 }
 
-interface Assets {
+export interface Assets {
   type: string;
   id: string;
   name: string;

--- a/lib/api/asset/v1/types.ts
+++ b/lib/api/asset/v1/types.ts
@@ -14,7 +14,7 @@ export interface Asset {
   rootAsset: string;
   parentAssetIds: string;
   patches?: Patch[];
-  versionNumber?: number
+  versionNumber?: number;
 }
 
 export interface AssetLocation {


### PR DESCRIPTION
- Added patchAsset in asset\v1\service to enable asset patching in mtfh-frontend-property.
- Updated Asset interface with versionNumber property, as the BE returns this. Set this to optional to avoid potential TS issues where Asset is already in use, and set some interfaces to be exported/public for use in tests.
- Added tests for patchAsset and useAsset.