### PR TITLE
MR-692 - PatchAsset - Set assetAddress type to correct one (EditAssetAddressRequest) - (retry)

### DIFF
--- a/lib/api/asset/v1/service.test.ts
+++ b/lib/api/asset/v1/service.test.ts
@@ -2,7 +2,7 @@ import { config } from "@mtfh/common/lib/config";
 import { axiosInstance, useAxiosSWR } from "@mtfh/common/lib/http";
 
 import { patchAsset, useAsset } from "./service";
-import { Asset, AssetAddress } from "./types";
+import { Asset, EditAssetAddressRequest } from "./types";
 
 jest.mock("@mtfh/common/lib/http", () => ({
   ...jest.requireActual("@mtfh/common/lib/http"),
@@ -14,14 +14,16 @@ jest.mock("@mtfh/common/lib/http", () => ({
 test("patchAsset: the API is called with the right parameters", async () => {
   const assetGuid = "15adc44b-6fde-46e8-af9c-e18b1495c9ab";
   const assetVersion = "3";
-  const assetAddress: AssetAddress = {
-    uprn: "100021045676",
-    addressLine1: "FLAT B",
-    addressLine2: "51 GREENWOOD ROAD",
-    addressLine3: "HACKNEY",
-    addressLine4: "LONDON",
-    postCode: "E8 1NT",
-    postPreamble: "",
+  const assetAddress: EditAssetAddressRequest = {
+    assetAddress: {
+      uprn: "100021045676",
+      addressLine1: "FLAT B",
+      addressLine2: "51 GREENWOOD ROAD",
+      addressLine3: "HACKNEY",
+      addressLine4: "LONDON",
+      postCode: "E8 1NT",
+      postPreamble: "",
+    },
   };
 
   patchAsset(assetGuid, assetAddress, assetVersion);

--- a/lib/api/asset/v1/service.ts
+++ b/lib/api/asset/v1/service.ts
@@ -6,7 +6,7 @@ import {
   useAxiosSWR,
 } from "@mtfh/common/lib/http";
 
-import { Asset, AssetAddress } from "./types";
+import { Asset, EditAssetAddressRequest } from "./types";
 
 export const useAsset = (
   id: string | null,
@@ -17,17 +17,16 @@ export const useAsset = (
 
 export const patchAsset = async (
   id: string,
-  assetAddress: AssetAddress,
+  assetAddress: EditAssetAddressRequest,
   assetVersion: string,
 ): Promise<void> => {
-  return new Promise<void>((resolve, reject) => {
+  return new Promise<void>((reject) => {
     axiosInstance
       .patch(`${config.assetApiUrlV1}/assets/${id}/address`, assetAddress, {
         headers: {
           "If-Match": assetVersion,
         },
       })
-      .then(() => resolve())
-      .catch(() => reject());
+      .catch((error) => reject(error));
   });
 };


### PR DESCRIPTION
Fixed test after PR #231 - Somehow the failing test was not picked by the pipeline, until the PR was merged into main.

Original PR description:

PatchAsset 
- Set assetAddress type to correct one (EditAssetAddressRequest)
- Added error to be returned on promise rejection#
- Removed then/resolve as not required

Error in mtfh-frontend-property:
![image](https://user-images.githubusercontent.com/70756861/222768225-67cfa89e-f3b5-471f-931e-68292a32ce07.png)
