### PR TITLE
MR-692 - PatchAsset API call edit

### DIFF
--- a/lib/api/asset/v1/service.ts
+++ b/lib/api/asset/v1/service.ts
@@ -20,13 +20,14 @@ export const patchAsset = async (
   assetAddress: EditAssetAddressRequest,
   assetVersion: string,
 ): Promise<void> => {
-  return new Promise<void>((reject) => {
+  return new Promise<void>((resolve, reject) => {
     axiosInstance
       .patch(`${config.assetApiUrlV1}/assets/${id}/address`, assetAddress, {
         headers: {
           "If-Match": assetVersion,
         },
       })
-      .catch((error) => reject(error));
+      .then(() => resolve())
+      .catch(() => reject());
   });
 };


### PR DESCRIPTION
For some reason after I last edited this, in case of an error, the returned promise would still be returned as fulfilled instead of rejected, meaning the `.catch` in mtfh-frontend-property, would never be called, but instead, despite the error, the `.then` code block would execute regardless.

Not sure why, so I'm setting this code back to when it was working fine/as expected.