### PR TITLE
MR-692 - Address getAddressViaUprn request now returns a promise

### DIFF
--- a/lib/api/address/v1/service.ts
+++ b/lib/api/address/v1/service.ts
@@ -27,20 +27,19 @@ export const searchAddress = async (postCode: string): Promise<SearchAddressResp
       return res;
     });
 
-export const getAddressViaUprn = async (UPRN: string): Promise<SearchAddressResponse> =>
-  axiosInstance
+
+export const getAddressViaUprn = async (  UPRN: string): Promise<SearchAddressResponse> => {
+  return new Promise<SearchAddressResponse>((resolve, reject) => {
+    axiosInstance
     .get<AddressAPIResponse>(`${config.addressApiUrlV1}/addresses?uprn=${UPRN}`, {
       headers: {
         "skip-x-correlation-id": true,
       },
     })
-    .then((res) => ({ addresses: res.data.data.address }))
-    .catch((res) => {
-      if (res.message.toLowerCase().indexOf("network") !== -1) {
-        return { error: { code: 500 } };
-      }
-      return res;
-    });
+    .then((res) => (resolve({ addresses: res.data.data.address })))
+    .catch((error) => reject(error));
+  });
+};
 
 export const useAddressLookup = (
   postCode?: string | null,

--- a/lib/api/address/v1/service.ts
+++ b/lib/api/address/v1/service.ts
@@ -27,17 +27,16 @@ export const searchAddress = async (postCode: string): Promise<SearchAddressResp
       return res;
     });
 
-
-export const getAddressViaUprn = async (  UPRN: string): Promise<SearchAddressResponse> => {
+export const getAddressViaUprn = async (UPRN: string): Promise<SearchAddressResponse> => {
   return new Promise<SearchAddressResponse>((resolve, reject) => {
     axiosInstance
-    .get<AddressAPIResponse>(`${config.addressApiUrlV1}/addresses?uprn=${UPRN}`, {
-      headers: {
-        "skip-x-correlation-id": true,
-      },
-    })
-    .then((res) => (resolve({ addresses: res.data.data.address })))
-    .catch((error) => reject(error));
+      .get<AddressAPIResponse>(`${config.addressApiUrlV1}/addresses?uprn=${UPRN}`, {
+        headers: {
+          "skip-x-correlation-id": true,
+        },
+      })
+      .then((res) => resolve({ addresses: res.data.data.address }))
+      .catch((error) => reject(error));
   });
 };
 


### PR DESCRIPTION
Edited getAddressViaUprn request to return a promise so that in case of errors, the catch block is triggered and the promise is rejected.

I was able to test this manually (in mtfh-frontend-property) and it works as intended:
- address found > `then()` block is executed
- any errors > `catch()` block is executed