### PR TITLE
Added endCautionaryAlert function to api/cautionary-alerts

### DIFF
--- a/lib/api/cautionary-alerts/v1/service.ts
+++ b/lib/api/cautionary-alerts/v1/service.ts
@@ -65,6 +65,6 @@ export const addCautionaryAlert = async (
 
 export const endCautionaryAlert = async (personId: string, alertId: string) => {
   await axiosInstance.patch(
-      `${config.cautionaryApiUrlV1}/persons/${personId}/alerts/${alertId}/end-alert`,
+    `${config.cautionaryApiUrlV1}/persons/${personId}/alerts/${alertId}/end-alert`,
   );
 };

--- a/lib/api/cautionary-alerts/v1/service.ts
+++ b/lib/api/cautionary-alerts/v1/service.ts
@@ -62,3 +62,9 @@ export const addCautionaryAlert = async (
     startDate: alert.dateOfIncident,
   };
 };
+
+export const endCautionaryAlert = async (personId: string, alertId: string) => {
+  await axiosInstance.patch(
+      `${config.cautionaryApiUrlV1}/persons/${personId}/alerts/${alertId}/end-alert`,
+  );
+};


### PR DESCRIPTION
This function is needed in the cautionary-alerts microfrontend in order to implement a process for ending cautionary alerts. 

[Relevant PR on Cautionary Alerts API](https://github.com/LBHackney-IT/cautionary-alerts-api/pull/101)

This is part of work to create a "manage cautionary alerts" page which will have an option for users with elevated access to end alerts.


