### PR TITLE
Add get Cautionary Alert by AlertId

### DIFF
--- a/lib/api/cautionary-alerts/v1/service.ts
+++ b/lib/api/cautionary-alerts/v1/service.ts
@@ -19,6 +19,16 @@ export const useCautionaryAlert = (
   );
 };
 
+export const useCautionaryAlertByAlertId = (
+  alertId: string,
+  options?: AxiosSWRConfiguration<any>,
+): AxiosSWRResponse<CautionaryAlert> => {
+  return useAxiosSWR(
+    alertId && `${config.cautionaryApiUrlV1}/cautionary-alerts/alert/${alertId}`,
+    options,
+  );
+};
+
 export const usePropertyCautionaryAlert = (
   propertyRef: string | null,
   options?: AxiosSWRConfiguration<any>,
@@ -63,8 +73,8 @@ export const addCautionaryAlert = async (
   };
 };
 
-export const endCautionaryAlert = async (personId: string, alertId: string) => {
+export const endCautionaryAlert = async (alertId: string) => {
   await axiosInstance.patch(
-      `${config.cautionaryApiUrlV1}/persons/${personId}/alerts/${alertId}/end-alert`,
+    `${config.cautionaryApiUrlV1}/cautionary-alerts/alerts/${alertId}/end-alert`,
   );
 };

--- a/lib/api/cautionary-alerts/v1/types.ts
+++ b/lib/api/cautionary-alerts/v1/types.ts
@@ -4,6 +4,7 @@ export type CautionaryAlert = {
 };
 
 export type Alert = {
+  alertId: string;
   alertCode: string;
   assureReference: string;
   dateModified: string;
@@ -14,4 +15,5 @@ export type Alert = {
   personId?: string;
   reason: string;
   startDate: string;
+  isActive: boolean;
 };

--- a/lib/utils/date-format/date-format.test.ts
+++ b/lib/utils/date-format/date-format.test.ts
@@ -29,7 +29,7 @@ test("is future date", () => {
 });
 
 test("formats the time correctly", () => {
-  expect(formatTime("2021-10-06T11:36:25.805Z")).toBe("11:36:25");
+  expect(formatTime("2023-03-16T11:36:25Z")).toBe("11:36:25");
 });
 
 test("formatted time will not break with a malformed date string", () => {


### PR DESCRIPTION
Added a function to get a cautionary alert by ID, matching the corresponding endpoint in the Cautionary Alerts API.

Added AlertID and IsActive properties to Cautionary Alert object.

No longer using PersonId in the PATCH URL, so it has been removed to align with the corresponding changes in the Cautionary Alerts API.