### PR TITLE
MR-692 - Asset version can be null when patching an asset

### DIFF
--- a/lib/api/asset/v1/service.ts
+++ b/lib/api/asset/v1/service.ts
@@ -18,7 +18,7 @@ export const useAsset = (
 export const patchAsset = async (
   id: string,
   assetAddress: EditAssetAddressRequest,
-  assetVersion: string,
+  assetVersion: string | null,
 ): Promise<void> => {
   return new Promise<void>((resolve, reject) => {
     axiosInstance


### PR DESCRIPTION
After numerous tests with Postman, we've established that sending a 'null' asset version works fine with the way Asset API is set up currently.

The Asset, that initially has a versionNumber of 'null', now gets PATCH'ed correctly when sending 'null' into patchAsset, and its versionNumber gets then updated automatically to a value of 0 (by DynamoDb)

![image](https://user-images.githubusercontent.com/70756861/225708546-caf803d8-4ce1-46cb-8d7f-2eeb186d88ae.png)

![image](https://user-images.githubusercontent.com/70756861/225708560-72f9a4fb-feae-4421-9f4f-4fc4caf74139.png)
