### PR TITLE
MR-698 - Created CreateNewAssetRequest interface for use when creating a new asset in MMH-Property

### DIFF
--- a/lib/api/asset/v1/service.test.ts
+++ b/lib/api/asset/v1/service.test.ts
@@ -2,7 +2,7 @@ import { config } from "@mtfh/common/lib/config";
 import { axiosInstance, useAxiosSWR } from "@mtfh/common/lib/http";
 
 import { createAsset, patchAsset, useAsset } from "./service";
-import { Asset, CreateAssetAddressRequest, EditAssetAddressRequest } from "./types";
+import { Asset, EditAssetAddressRequest } from "./types";
 
 jest.mock("@mtfh/common/lib/http", () => ({
   ...jest.requireActual("@mtfh/common/lib/http"),
@@ -98,7 +98,7 @@ test("useAsset: the API is called with the right parameters", async () => {
 });
 
 test("createAsset: the API is called with the right parameters", async () => {
-  const body: CreateAssetAddressRequest = {
+  const body = {
     id: "3f44819f-f3b4-4363-88b6-4575aa4bc5b0",
     assetId: "1234",
     parentAssetIds: "",

--- a/lib/api/asset/v1/service.test.ts
+++ b/lib/api/asset/v1/service.test.ts
@@ -2,7 +2,7 @@ import { config } from "@mtfh/common/lib/config";
 import { axiosInstance, useAxiosSWR } from "@mtfh/common/lib/http";
 
 import { createAsset, patchAsset, useAsset } from "./service";
-import { Asset, EditAssetAddressRequest } from "./types";
+import { Asset, CreateNewAsset, EditAssetAddressRequest } from "./types";
 
 jest.mock("@mtfh/common/lib/http", () => ({
   ...jest.requireActual("@mtfh/common/lib/http"),
@@ -98,10 +98,10 @@ test("useAsset: the API is called with the right parameters", async () => {
 });
 
 test("createAsset: the API is called with the right parameters", async () => {
-  const body = {
+  const body: CreateNewAsset = {
     id: "3f44819f-f3b4-4363-88b6-4575aa4bc5b0",
     assetId: "1234",
-    parentAssetIds: "",
+    parentAssetIds: [],
     assetType: "Dwelling",
     assetLocation: {
       floorNo: "",
@@ -120,11 +120,10 @@ test("createAsset: the API is called with the right parameters", async () => {
     assetManagement: {
       agent: "Sanctuary Housing Association",
       areaOfficeName: "",
-      isCouncilProperty: false,
+      isCouncilProperty: true,
       managingOrganisation: "London Borough of Hackney",
       isTMOManaged: false,
       managingOrganisationId: "c01e3146-e630-c2cd-e709-18ef57bf3724",
-      owner: "",
     },
     assetCharacteristics: {
       numberOfBedrooms: 1,
@@ -133,10 +132,6 @@ test("createAsset: the API is called with the right parameters", async () => {
       windowType: "DBL",
       yearConstructed: "0",
     },
-    rootAsset: "",
-    tenure: null,
-    versionNumber: 2,
-    patches: [],
   };
 
   createAsset(body);

--- a/lib/api/asset/v1/service.test.ts
+++ b/lib/api/asset/v1/service.test.ts
@@ -1,12 +1,12 @@
 import { config } from "@mtfh/common/lib/config";
 import { axiosInstance, useAxiosSWR } from "@mtfh/common/lib/http";
 
-import { patchAsset, useAsset } from "./service";
-import { Asset, EditAssetAddressRequest } from "./types";
+import { createAsset, patchAsset, useAsset } from "./service";
+import { Asset, CreateAssetAddressRequest, EditAssetAddressRequest } from "./types";
 
 jest.mock("@mtfh/common/lib/http", () => ({
   ...jest.requireActual("@mtfh/common/lib/http"),
-  axiosInstance: { patch: jest.fn() },
+  axiosInstance: { patch: jest.fn(), post: jest.fn() },
   useAxiosSWR: jest.fn(),
   mutate: jest.fn(),
 }));
@@ -43,7 +43,7 @@ test("useAsset: the API is called with the right parameters", async () => {
     rootAsset: "",
     parentAssetIds: "",
     assetLocation: {
-      floorNo: 4,
+      floorNo: "4",
       totalBlockFloors: 6,
       parentAssets: [{ id: "123", name: "asset", type: "asset-type" }],
     },
@@ -95,4 +95,51 @@ test("useAsset: the API is called with the right parameters", async () => {
     undefined,
   );
   expect(response).toBe(returnedValue);
+});
+
+test("createAsset: the API is called with the right parameters", async () => {
+  const body: CreateAssetAddressRequest = {
+    id: "3f44819f-f3b4-4363-88b6-4575aa4bc5b0",
+    assetId: "1234",
+    parentAssetIds: "",
+    assetType: "Dwelling",
+    assetLocation: {
+      floorNo: "",
+      totalBlockFloors: 0,
+      parentAssets: [],
+    },
+    assetAddress: {
+      uprn: "100023022032",
+      addressLine1: "20000 Butfield House Stevens Avenue",
+      addressLine2: "London",
+      addressLine3: "",
+      addressLine4: "",
+      postCode: "E9 6RS",
+      postPreamble: "",
+    },
+    assetManagement: {
+      agent: "Sanctuary Housing Association",
+      areaOfficeName: "",
+      isCouncilProperty: false,
+      managingOrganisation: "London Borough of Hackney",
+      isTMOManaged: false,
+      managingOrganisationId: "c01e3146-e630-c2cd-e709-18ef57bf3724",
+      owner: "",
+    },
+    assetCharacteristics: {
+      numberOfBedrooms: 1,
+      numberOfLifts: 0,
+      numberOfLivingRooms: 0,
+      windowType: "DBL",
+      yearConstructed: "0",
+    },
+    rootAsset: "",
+    tenure: null,
+    versionNumber: 2,
+    patches: [],
+  };
+
+  createAsset(body);
+
+  expect(axiosInstance.post).toBeCalledWith(`${config.assetApiUrlV1}/assets/`, body);
 });

--- a/lib/api/asset/v1/service.test.ts
+++ b/lib/api/asset/v1/service.test.ts
@@ -2,7 +2,7 @@ import { config } from "@mtfh/common/lib/config";
 import { axiosInstance, useAxiosSWR } from "@mtfh/common/lib/http";
 
 import { createAsset, patchAsset, useAsset } from "./service";
-import { Asset, CreateNewAsset, EditAssetAddressRequest } from "./types";
+import { Asset, CreateNewAssetRequest, EditAssetAddressRequest } from "./types";
 
 jest.mock("@mtfh/common/lib/http", () => ({
   ...jest.requireActual("@mtfh/common/lib/http"),
@@ -98,7 +98,7 @@ test("useAsset: the API is called with the right parameters", async () => {
 });
 
 test("createAsset: the API is called with the right parameters", async () => {
-  const body: CreateNewAsset = {
+  const body: CreateNewAssetRequest = {
     id: "3f44819f-f3b4-4363-88b6-4575aa4bc5b0",
     assetId: "1234",
     parentAssetIds: [],

--- a/lib/api/asset/v1/service.test.ts
+++ b/lib/api/asset/v1/service.test.ts
@@ -103,7 +103,7 @@ describe("useAsset", () => {
 
 describe("createAsset", () => {
   test("it calls the api endpoint with the correct url and parameters", async () => {
-    const body: CreateAssetAddressRequest = {
+    const body: CreateNewAssetRequest = {
       id: "3f44819f-f3b4-4363-88b6-4575aa4bc5b0",
       assetId: "1234",
       parentAssetIds: "",
@@ -125,11 +125,10 @@ describe("createAsset", () => {
       assetManagement: {
         agent: "Sanctuary Housing Association",
         areaOfficeName: "",
-        isCouncilProperty: false,
+        isCouncilProperty: true,
         managingOrganisation: "London Borough of Hackney",
         isTMOManaged: false,
         managingOrganisationId: "c01e3146-e630-c2cd-e709-18ef57bf3724",
-        owner: "",
       },
       assetCharacteristics: {
         numberOfBedrooms: 1,
@@ -138,10 +137,6 @@ describe("createAsset", () => {
         windowType: "DBL",
         yearConstructed: "0",
       },
-      rootAsset: "",
-      tenure: null,
-      versionNumber: 2,
-      patches: [],
     };
 
     createAsset(body);

--- a/lib/api/asset/v1/service.ts
+++ b/lib/api/asset/v1/service.ts
@@ -6,7 +6,7 @@ import {
   useAxiosSWR,
 } from "@mtfh/common/lib/http";
 
-import { Asset, EditAssetAddressRequest } from "./types";
+import { Asset, CreateAssetAddressRequest, EditAssetAddressRequest } from "./types";
 
 export const useAsset = (
   id: string | null,
@@ -19,7 +19,7 @@ export const patchAsset = async (
   id: string,
   assetAddress: EditAssetAddressRequest,
   assetVersion: string | null,
-): Promise<void> => {
+) => {
   return new Promise<void>((resolve, reject) => {
     axiosInstance
       .patch(`${config.assetApiUrlV1}/assets/${id}/address`, assetAddress, {
@@ -27,6 +27,15 @@ export const patchAsset = async (
           "If-Match": assetVersion,
         },
       })
+      .then(() => resolve())
+      .catch(() => reject());
+  });
+};
+
+export const createAsset = async (request: CreateAssetAddressRequest) => {
+  return new Promise<void>((resolve, reject) => {
+    axiosInstance
+      .post(`${config.assetApiUrlV1}/assets/`, request)
       .then(() => resolve())
       .catch(() => reject());
   });

--- a/lib/api/asset/v1/service.ts
+++ b/lib/api/asset/v1/service.ts
@@ -6,7 +6,7 @@ import {
   useAxiosSWR,
 } from "@mtfh/common/lib/http";
 
-import { Asset, CreateNewAsset, EditAssetAddressRequest } from "./types";
+import { Asset, CreateNewAssetRequest, EditAssetAddressRequest } from "./types";
 
 export const useAsset = (
   id: string | null,
@@ -32,7 +32,7 @@ export const patchAsset = async (
   });
 };
 
-export const createAsset = async (request: CreateNewAsset) => {
+export const createAsset = async (request: CreateNewAssetRequest) => {
   return new Promise<void>((resolve, reject) => {
     axiosInstance
       .post(`${config.assetApiUrlV1}/assets/`, request)

--- a/lib/api/asset/v1/service.ts
+++ b/lib/api/asset/v1/service.ts
@@ -6,7 +6,7 @@ import {
   useAxiosSWR,
 } from "@mtfh/common/lib/http";
 
-import { Asset, CreateAssetAddressRequest, EditAssetAddressRequest } from "./types";
+import { Asset, EditAssetAddressRequest } from "./types";
 
 export const useAsset = (
   id: string | null,
@@ -32,7 +32,7 @@ export const patchAsset = async (
   });
 };
 
-export const createAsset = async (request: CreateAssetAddressRequest) => {
+export const createAsset = async (request: any) => {
   return new Promise<void>((resolve, reject) => {
     axiosInstance
       .post(`${config.assetApiUrlV1}/assets/`, request)

--- a/lib/api/asset/v1/service.ts
+++ b/lib/api/asset/v1/service.ts
@@ -6,7 +6,7 @@ import {
   useAxiosSWR,
 } from "@mtfh/common/lib/http";
 
-import { Asset, EditAssetAddressRequest } from "./types";
+import { Asset, CreateNewAsset, EditAssetAddressRequest } from "./types";
 
 export const useAsset = (
   id: string | null,
@@ -32,7 +32,7 @@ export const patchAsset = async (
   });
 };
 
-export const createAsset = async (request: any) => {
+export const createAsset = async (request: CreateNewAsset) => {
   return new Promise<void>((resolve, reject) => {
     axiosInstance
       .post(`${config.assetApiUrlV1}/assets/`, request)

--- a/lib/api/asset/v1/types.ts
+++ b/lib/api/asset/v1/types.ts
@@ -18,12 +18,12 @@ export interface Asset {
 }
 
 export interface AssetLocation {
-  floorNo: number;
+  floorNo: string;
   totalBlockFloors: number;
-  parentAssets: Assets[];
+  parentAssets: ParentAsset[];
 }
 
-export interface Assets {
+export interface ParentAsset {
   type: string;
   id: string;
   name: string;
@@ -39,7 +39,7 @@ export interface AssetAddress {
   postPreamble: string;
 }
 
-interface AssetManagement {
+export interface AssetManagement {
   agent: string;
   areaOfficeName: string;
   isCouncilProperty: boolean;
@@ -49,11 +49,11 @@ interface AssetManagement {
   isTMOManaged: boolean;
 }
 
-interface AssetCharacteristics {
+export interface AssetCharacteristics {
   numberOfBedrooms: number;
   numberOfLifts: number;
   numberOfLivingRooms: number;
-  windowType: "DBL";
+  windowType: string;
   yearConstructed: string;
 }
 
@@ -69,3 +69,5 @@ export interface AssetTenure {
 export interface EditAssetAddressRequest {
   assetAddress: AssetAddress;
 }
+
+export type CreateAssetAddressRequest = Asset;

--- a/lib/api/asset/v1/types.ts
+++ b/lib/api/asset/v1/types.ts
@@ -92,9 +92,9 @@ export interface CreateNewAsset {
   assetManagement: {
     agent: string,
     areaOfficeName: string,
-    isCouncilProperty: string,
+    isCouncilProperty: boolean,
     managingOrganisation: string,
-    isTMOManaged: string,
+    isTMOManaged: boolean,
     managingOrganisationId: string,
   },
   assetCharacteristics: {

--- a/lib/api/asset/v1/types.ts
+++ b/lib/api/asset/v1/types.ts
@@ -69,3 +69,39 @@ export interface AssetTenure {
 export interface EditAssetAddressRequest {
   assetAddress: AssetAddress;
 }
+
+export interface CreateNewAsset {
+  id: string
+  assetId: string
+  assetType: string
+  parentAssetIds: string[]
+  assetLocation: {
+    floorNo: string,
+    totalBlockFloors: number,
+    parentAssets: any[],
+  },
+  assetAddress: {
+    uprn: string,
+    addressLine1: string,
+    addressLine2: string,
+    addressLine3: string,
+    addressLine4: string,
+    postCode: string,
+    postPreamble: string,
+  },
+  assetManagement: {
+    agent: string,
+    areaOfficeName: string,
+    isCouncilProperty: string,
+    managingOrganisation: string,
+    isTMOManaged: string,
+    managingOrganisationId: string,
+  },
+  assetCharacteristics: {
+    numberOfBedrooms: number,
+    numberOfLivingRooms: number,
+    yearConstructed: string,
+    windowType: string,
+    numberOfLifts: number,
+  },
+}

--- a/lib/api/asset/v1/types.ts
+++ b/lib/api/asset/v1/types.ts
@@ -69,5 +69,3 @@ export interface AssetTenure {
 export interface EditAssetAddressRequest {
   assetAddress: AssetAddress;
 }
-
-export type CreateAssetAddressRequest = Asset;

--- a/lib/api/asset/v1/types.ts
+++ b/lib/api/asset/v1/types.ts
@@ -70,7 +70,7 @@ export interface EditAssetAddressRequest {
   assetAddress: AssetAddress;
 }
 
-export interface CreateNewAsset {
+export interface CreateNewAssetRequest {
   id: string
   assetId: string
   assetType: string


### PR DESCRIPTION
Apologies for the many commits, this branch was mostly used for testing a few changes to the createAsset request, specifically to the type of object it receives as a parameter. 

A new interface has been created for CreateNewAssetRequest (rather than using Asset as reference).

This interface only incorporates the fields captured by the New Asset Form in MMH (`{mmh-url}/property/new`)