### PR TITLE
MR-698 - Numeric values in CreateNewAssetRequest  that are not required by New Asset form are now nullable

### DIFF
--- a/lib/api/asset/v1/types.ts
+++ b/lib/api/asset/v1/types.ts
@@ -77,7 +77,7 @@ export interface CreateNewAssetRequest {
   parentAssetIds: string;
   assetLocation: {
     floorNo: string;
-    totalBlockFloors: number;
+    totalBlockFloors: number | null;
     parentAssets: any[];
   };
   assetAddress: {
@@ -98,10 +98,10 @@ export interface CreateNewAssetRequest {
     managingOrganisationId: string;
   };
   assetCharacteristics: {
-    numberOfBedrooms: number;
-    numberOfLivingRooms: number;
+    numberOfBedrooms: number | null;
+    numberOfLivingRooms: number | null;
     yearConstructed: string;
     windowType: string;
-    numberOfLifts: number;
+    numberOfLifts: number | null;
   };
 }

--- a/lib/api/asset/v1/types.ts
+++ b/lib/api/asset/v1/types.ts
@@ -87,7 +87,6 @@ export interface CreateNewAssetRequest {
     addressLine3: string;
     addressLine4: string;
     postCode: string;
-    postPreamble: string;
   };
   assetManagement: {
     agent: string;


### PR DESCRIPTION
Numeric values in CreateNewAssetRequest  that are not required by New Asset form are now nullable.

This prevents them being converted to 0 and end up being misleading.

Also removed postPreamble from CreateNewAssetRequest as not currently required