### PR TITLE
MR-698 - Added isActive property to CreateNewAssetRequest object 

### DIFF
--- a/lib/api/asset/v1/service.test.ts
+++ b/lib/api/asset/v1/service.test.ts
@@ -108,6 +108,7 @@ describe("createAsset", () => {
       assetId: "1234",
       parentAssetIds: "",
       assetType: "Dwelling",
+      isActive: true,
       assetLocation: {
         floorNo: "",
         totalBlockFloors: 0,

--- a/lib/api/asset/v1/types.ts
+++ b/lib/api/asset/v1/types.ts
@@ -74,6 +74,7 @@ export interface CreateNewAssetRequest {
   id: string;
   assetId: string;
   assetType: string;
+  isActive: boolean;
   parentAssetIds: string;
   assetLocation: {
     floorNo: string;


### PR DESCRIPTION
Added isActive property to CreateNewAssetRequest object.

This value will be sent as 'true' every time a new asset is create from the 'new asset' form in `mtfh-frontend-property` (see PR https://github.com/LBHackney-IT/mtfh-frontend-property/pull/51)