### PR TITLE
add end date to endCA API request

### DIFF
--- a/lib/api/cautionary-alerts/v1/service.ts
+++ b/lib/api/cautionary-alerts/v1/service.ts
@@ -73,8 +73,16 @@ export const addCautionaryAlert = async (
   };
 };
 
-export const endCautionaryAlert = async (alertId: string) => {
+export interface EndCautionaryAlertRequestData {
+  endDate: Date;
+}
+
+export const endCautionaryAlert = async (
+  alertId: string,
+  data: EndCautionaryAlertRequestData,
+) => {
   await axiosInstance.patch(
     `${config.cautionaryApiUrlV1}/cautionary-alerts/alerts/${alertId}/end-alert`,
+    data,
   );
 };


### PR DESCRIPTION
When sending through an EndCautionaryAlert API request, an end date should be provided as part of the request data. 