### PR TITLE
Fixup editTenuredAsset call

### DIFF
--- a/lib/api/tenure/v1/service.ts
+++ b/lib/api/tenure/v1/service.ts
@@ -83,13 +83,14 @@ export const editTenure = async ({ id, ...data }: EditTenureParams): Promise<voi
   return response.data;
 };
 
-export const editTenuredAsset = async ({
-  id,
-  ...data
-}: EditTenuredAssetParams): Promise<void> => {
-  const response = await axiosInstance.patch(
-    `${config.tenureApiUrlV1}/tenures/${id}`,
-    data,
-  );
-  return response.data;
+export const editTenuredAsset = async (
+  id: string,
+  tenuredAssetUpdate: EditTenuredAssetParams,
+) => {
+  return new Promise<void>((resolve, reject) => {
+    axiosInstance
+      .patch(`${config.tenureApiUrlV1}/tenures/${id}`, tenuredAssetUpdate, {})
+      .then(() => resolve())
+      .catch(() => reject());
+  });
 };

--- a/lib/api/tenure/v1/service.ts
+++ b/lib/api/tenure/v1/service.ts
@@ -69,9 +69,6 @@ export const removePersonFromTenure = async (
 export interface EditTenureParams extends Partial<TenureParams> {
   id: string;
   etag: string;
-}
-
-export interface EditTenuredAssetParams extends EditTenureParams {
   tenuredAsset?: TenureAsset | null;
 }
 
@@ -81,16 +78,4 @@ export const editTenure = async ({ id, ...data }: EditTenureParams): Promise<voi
     data,
   );
   return response.data;
-};
-
-export const editTenuredAsset = async (
-  id: string,
-  tenuredAssetUpdate: EditTenuredAssetParams,
-) => {
-  return new Promise<void>((resolve, reject) => {
-    axiosInstance
-      .patch(`${config.tenureApiUrlV1}/tenures/${id}`, tenuredAssetUpdate, {})
-      .then(() => resolve())
-      .catch(() => reject());
-  });
 };


### PR DESCRIPTION
- The shared axios implementation uses the etag field to set the if-match header - bit of a bizarre way of doing it but there we go
- As this is part of the object itself and is decoded in the shared http.ts library, we don't need to doa ny manual setting of this item