### PR TITLE
Added Post Preamble and Patches (nullable) fields to CreateNewAssetRequest interface

### DIFF
--- a/lib/api/asset/v1/service.test.ts
+++ b/lib/api/asset/v1/service.test.ts
@@ -138,7 +138,7 @@ describe("createAsset", () => {
         windowType: "DBL",
         yearConstructed: "0",
       },
-      patches: undefined
+      patches: undefined,
     };
 
     createAsset(body);

--- a/lib/api/asset/v1/service.test.ts
+++ b/lib/api/asset/v1/service.test.ts
@@ -116,6 +116,7 @@ describe("createAsset", () => {
       },
       assetAddress: {
         uprn: "100023022032",
+        postPreamble: "",
         addressLine1: "20000 Butfield House Stevens Avenue",
         addressLine2: "London",
         addressLine3: "",
@@ -137,6 +138,7 @@ describe("createAsset", () => {
         windowType: "DBL",
         yearConstructed: "0",
       },
+      patches: undefined
     };
 
     createAsset(body);

--- a/lib/api/asset/v1/types.ts
+++ b/lib/api/asset/v1/types.ts
@@ -83,6 +83,7 @@ export interface CreateNewAssetRequest {
   };
   assetAddress: {
     uprn: string;
+    postPreamble: string;
     addressLine1: string;
     addressLine2: string;
     addressLine3: string;
@@ -104,4 +105,5 @@ export interface CreateNewAssetRequest {
     windowType: string;
     numberOfLifts: number | null;
   };
+  patches?: Patch[];
 }


### PR DESCRIPTION
With relation to PR: https://github.com/LBHackney-IT/mtfh-frontend-property/pull/74

Added Post Preamble (string) and Patches (nullable) field to CreateNewAssetRequest interface.

The New Asset form will require these two new fields.

