### PR TITLE
MR-698 - Add Patches & Areas API call

### DIFF
--- a/lib/api/patch/service.ts
+++ b/lib/api/patch/service.ts
@@ -1,0 +1,17 @@
+import { config } from "@mtfh/common/lib/config";
+import { axiosInstance } from "@mtfh/common/lib/http";
+
+import { Patch } from "./v1";
+
+export const getAllPatchesAndAreas = async (): Promise<Array<Patch>> => {
+  return new Promise<Array<Patch>>((resolve, reject) => {
+    axiosInstance
+      .get<Array<Patch>>(`${config.patchesAndAreasApiUrlV1}/patch/all`, {
+        headers: {
+          "skip-x-correlation-id": true,
+        },
+      })
+      .then((res) => resolve(res.data))
+      .catch((error) => reject(error));
+  });
+};

--- a/lib/api/patch/v1/service.test.ts
+++ b/lib/api/patch/v1/service.test.ts
@@ -1,0 +1,22 @@
+import { config } from "@mtfh/common/lib/config";
+import { axiosInstance } from "@mtfh/common/lib/http";
+
+import { getAllPatchesAndAreas } from "../service";
+
+jest.mock("@mtfh/common/lib/http", () => ({
+  ...jest.requireActual("@mtfh/common/lib/http"),
+  axiosInstance: { get: jest.fn() },
+  useAxiosSWR: jest.fn(),
+  mutate: jest.fn(),
+}));
+
+describe("getAllPatchesAndAreas", () => {
+  test("it should call the getAllPatchesAndAreas API endpoint with the correct URL and headers", async () => {
+    getAllPatchesAndAreas();
+
+    expect(axiosInstance.get).toBeCalledWith(
+      `${config.patchesAndAreasApiUrlV1}/patch/all`,
+      { headers: { "skip-x-correlation-id": true } },
+    );
+  });
+});

--- a/lib/config/config.ts
+++ b/lib/config/config.ts
@@ -14,6 +14,7 @@ const config = {
   notesApiUrlV2: process.env.NOTES_API_URL_V2 || "/api/v2",
   tenureApiUrlV1: process.env.TENURE_API_URL_V1 || "/api/v1",
   assetApiUrlV1: process.env.PROPERTY_API_URL_V1 || "/api/v1",
+  patchesAndAreasApiUrlV1: process.env.PATCHES_AND_AREAS_API_V1 || "/api/v1",
   referenceDataApiUrlV1: process.env.REFERENCE_DATA_API_URL_V1 || "/api/v1",
   addressApiUrlV1: process.env.ADDRESS_API_URL_V1 || "/api/v1",
   addressApiUrlV2: process.env.ADDRESS_API_URL_V2 || "/api/v2",


### PR DESCRIPTION
Following PR https://github.com/LBHackney-IT/patches-and-areas-api/pull/43, the "Add new asset" form within MMH (Property MFE) requires a call to the new GetAllPatchesAndAreas endpoint in Patches & Areas API, to populate the Patch options.

- Updated config.ts file with new entry for Patches & Areas API V1
- Created new service file with call to getAllPatchesAndAreas endpoint
- Created test

**Note: .env file will require a new entry PATCHES_AND_AREAS_API_V1**