### PR TITLE
Refactored asset mocks to allow for universal access

### DIFF
--- a/lib/api/asset/v1/mocks.ts
+++ b/lib/api/asset/v1/mocks.ts
@@ -9,6 +9,7 @@ import {
   CreateNewAssetRequest,
   EditAssetAddressRequest,
   ParentAsset,
+  RentGroup,
 } from "./types";
 
 export const mockAssetTenure: AssetTenure = {
@@ -64,13 +65,16 @@ export const mockParentAsset: ParentAsset = {
 export const mockAssetLocation: AssetLocation = {
   floorNo: "4",
   totalBlockFloors: 6,
-  parentAssets: [{ id: "123", name: "asset", type: "asset-type" }],
+  parentAssets: [
+    { id: "af3b672d-aafd-46ad-81ca-a747ee77b2fd", name: "asset", type: "asset-type" },
+  ],
 };
 
 export const mockAsset: Asset = {
   id: "15adc44b-6fde-46e8-af9c-e18b1495c9ab",
   assetId: "100021045676",
   assetType: "LettableNonDwelling",
+  rentGroup: RentGroup.HRA,
   rootAsset: "",
   parentAssetIds: "",
   assetLocation: mockAssetLocation,

--- a/lib/api/asset/v1/mocks.ts
+++ b/lib/api/asset/v1/mocks.ts
@@ -5,12 +5,13 @@ import {
   AssetCharacteristics,
   AssetLocation,
   AssetManagement,
+  AssetTenure,
   CreateNewAssetRequest,
   EditAssetAddressRequest,
   ParentAsset,
 } from "./types";
 
-export const mockAssetTenure = {
+export const mockAssetTenure: AssetTenure = {
   id: "123",
   paymentReference: "123",
   type: "type",
@@ -87,28 +88,9 @@ export const mockCreateNewAssetRequest: CreateNewAssetRequest = {
   parentAssetIds: "",
   assetType: "Dwelling",
   isActive: true,
-  assetLocation: {
-    floorNo: "",
-    totalBlockFloors: 0,
-    parentAssets: [],
-  },
-  assetAddress: {
-    uprn: "100023022032",
-    postPreamble: "",
-    addressLine1: "20000 Butfield House Stevens Avenue",
-    addressLine2: "London",
-    addressLine3: "",
-    addressLine4: "",
-    postCode: "E9 6RS",
-  },
-  assetManagement: {
-    agent: "Sanctuary Housing Association",
-    areaOfficeName: "",
-    isCouncilProperty: true,
-    managingOrganisation: "London Borough of Hackney",
-    isTMOManaged: false,
-    managingOrganisationId: "c01e3146-e630-c2cd-e709-18ef57bf3724",
-  },
+  assetLocation: mockAssetLocation,
+  assetAddress: mockAssetAddress,
+  assetManagement: mockAssetManagement,
   assetCharacteristics: {
     numberOfBedrooms: 1,
     numberOfLifts: 0,
@@ -116,7 +98,7 @@ export const mockCreateNewAssetRequest: CreateNewAssetRequest = {
     windowType: "DBL",
     yearConstructed: "0",
   },
-  patches: undefined,
+  patches: [mockPatch],
 };
 
 export const mockEditAssetAddressRequest: EditAssetAddressRequest = {

--- a/lib/api/asset/v1/mocks.ts
+++ b/lib/api/asset/v1/mocks.ts
@@ -1,4 +1,70 @@
-import { Asset, CreateNewAssetRequest, EditAssetAddressRequest } from "./types";
+import { mockPatch } from "../../patch/v1/mocks";
+import {
+  Asset,
+  AssetAddress,
+  AssetCharacteristics,
+  AssetLocation,
+  AssetManagement,
+  CreateNewAssetRequest,
+  EditAssetAddressRequest,
+  ParentAsset,
+} from "./types";
+
+export const mockAssetTenure = {
+  id: "123",
+  paymentReference: "123",
+  type: "type",
+  startOfTenureDate: "2020-01-01",
+  endOfTenureDate: "2020-01-01",
+  isActive: true,
+};
+
+export const mockAssetCharacteristics: AssetCharacteristics = {
+  numberOfBedrooms: 2,
+  numberOfLifts: 1,
+  numberOfLivingRooms: 1,
+  windowType: "DBL",
+  yearConstructed: "2077",
+  numberOfSingleBeds: 1,
+  numberOfDoubleBeds: 1,
+  numberOfFloors: 2,
+  totalBlockFloors: 5,
+  heating: "FCB",
+  propertyFactor: "4.5",
+  architecturalType: "PRE45MR-FLT",
+};
+
+export const mockAssetManagement: AssetManagement = {
+  agent: "London Borough of Hackney",
+  areaOfficeName: "areaOfficeName",
+  isCouncilProperty: false,
+  managingOrganisation: "London Borough of Hackney",
+  managingOrganisationId: "97dd3725-69c3-4adf-bd0f-523342abbd6f",
+  owner: "ABC",
+  isTMOManaged: false,
+};
+
+export const mockAssetAddress: AssetAddress = {
+  uprn: "100021045676",
+  addressLine1: "FLAT B",
+  addressLine2: "51 GREENWOOD ROAD",
+  addressLine3: "HACKNEY",
+  addressLine4: "LONDON",
+  postCode: "E8 1NT",
+  postPreamble: "",
+};
+
+export const mockParentAsset: ParentAsset = {
+  type: "LettableNonDwelling",
+  id: "97dd3725-69c3-4adf-bd0f-523342abbd6f",
+  name: "asset",
+};
+
+export const mockAssetLocation: AssetLocation = {
+  floorNo: "4",
+  totalBlockFloors: 6,
+  parentAssets: [{ id: "123", name: "asset", type: "asset-type" }],
+};
 
 export const mockAsset: Asset = {
   id: "15adc44b-6fde-46e8-af9c-e18b1495c9ab",
@@ -6,55 +72,13 @@ export const mockAsset: Asset = {
   assetType: "LettableNonDwelling",
   rootAsset: "",
   parentAssetIds: "",
-  assetLocation: {
-    floorNo: "4",
-    totalBlockFloors: 6,
-    parentAssets: [{ id: "123", name: "asset", type: "asset-type" }],
-  },
-  assetAddress: {
-    uprn: "100021045676",
-    addressLine1: "FLAT B",
-    addressLine2: "51 GREENWOOD ROAD",
-    addressLine3: "HACKNEY",
-    addressLine4: "LONDON",
-    postCode: "E8 1NT",
-    postPreamble: "",
-  },
-  assetManagement: {
-    agent: "agent",
-    areaOfficeName: "areaOfficeName",
-    isCouncilProperty: true,
-    managingOrganisation: "org",
-    managingOrganisationId: "456",
-    owner: "owner",
-    isTMOManaged: true,
-  },
-  assetCharacteristics: {
-    numberOfBedrooms: 2,
-    numberOfLifts: 1,
-    numberOfLivingRooms: 1,
-    windowType: "DBL",
-    yearConstructed: "2077",
-    numberOfSingleBeds: 1,
-    numberOfDoubleBeds: 1,
-    numberOfFloors: 2,
-    totalBlockFloors: 5,
-    heating: "FCB",
-    propertyFactor: "4.5",
-    architecturalType: "PRE45MR-FLT",
-  },
-  tenure: null,
+  assetLocation: mockAssetLocation,
+  assetAddress: mockAssetAddress,
+  assetManagement: mockAssetManagement,
+  assetCharacteristics: mockAssetCharacteristics,
+  tenure: mockAssetTenure,
   versionNumber: 2,
-  patches: [
-    {
-      id: "bd0a8e2b-c3b5-4628-aa33-8e7509d5eac6",
-      parentId: "8d4fb05d-3ff5-48b7-a17a-71fcb27a66a8",
-      name: "SN4",
-      patchType: "patch",
-      domain: "MMH",
-      responsibleEntities: [],
-    },
-  ],
+  patches: [mockPatch],
 };
 
 export const mockCreateNewAssetRequest: CreateNewAssetRequest = {

--- a/lib/api/asset/v1/mocks.ts
+++ b/lib/api/asset/v1/mocks.ts
@@ -1,0 +1,108 @@
+import { Asset, CreateNewAssetRequest, EditAssetAddressRequest } from "./types";
+
+export const mockAsset: Asset = {
+  id: "15adc44b-6fde-46e8-af9c-e18b1495c9ab",
+  assetId: "100021045676",
+  assetType: "LettableNonDwelling",
+  rootAsset: "",
+  parentAssetIds: "",
+  assetLocation: {
+    floorNo: "4",
+    totalBlockFloors: 6,
+    parentAssets: [{ id: "123", name: "asset", type: "asset-type" }],
+  },
+  assetAddress: {
+    uprn: "100021045676",
+    addressLine1: "FLAT B",
+    addressLine2: "51 GREENWOOD ROAD",
+    addressLine3: "HACKNEY",
+    addressLine4: "LONDON",
+    postCode: "E8 1NT",
+    postPreamble: "",
+  },
+  assetManagement: {
+    agent: "agent",
+    areaOfficeName: "areaOfficeName",
+    isCouncilProperty: true,
+    managingOrganisation: "org",
+    managingOrganisationId: "456",
+    owner: "owner",
+    isTMOManaged: true,
+  },
+  assetCharacteristics: {
+    numberOfBedrooms: 2,
+    numberOfLifts: 1,
+    numberOfLivingRooms: 1,
+    windowType: "DBL",
+    yearConstructed: "2077",
+    numberOfSingleBeds: 1,
+    numberOfDoubleBeds: 1,
+    numberOfFloors: 2,
+    totalBlockFloors: 5,
+    heating: "FCB",
+    propertyFactor: "4.5",
+    architecturalType: "PRE45MR-FLT",
+  },
+  tenure: null,
+  versionNumber: 2,
+  patches: [
+    {
+      id: "bd0a8e2b-c3b5-4628-aa33-8e7509d5eac6",
+      parentId: "8d4fb05d-3ff5-48b7-a17a-71fcb27a66a8",
+      name: "SN4",
+      patchType: "patch",
+      domain: "MMH",
+      responsibleEntities: [],
+    },
+  ],
+};
+
+export const mockCreateNewAssetRequest: CreateNewAssetRequest = {
+  id: "3f44819f-f3b4-4363-88b6-4575aa4bc5b0",
+  assetId: "1234",
+  parentAssetIds: "",
+  assetType: "Dwelling",
+  isActive: true,
+  assetLocation: {
+    floorNo: "",
+    totalBlockFloors: 0,
+    parentAssets: [],
+  },
+  assetAddress: {
+    uprn: "100023022032",
+    postPreamble: "",
+    addressLine1: "20000 Butfield House Stevens Avenue",
+    addressLine2: "London",
+    addressLine3: "",
+    addressLine4: "",
+    postCode: "E9 6RS",
+  },
+  assetManagement: {
+    agent: "Sanctuary Housing Association",
+    areaOfficeName: "",
+    isCouncilProperty: true,
+    managingOrganisation: "London Borough of Hackney",
+    isTMOManaged: false,
+    managingOrganisationId: "c01e3146-e630-c2cd-e709-18ef57bf3724",
+  },
+  assetCharacteristics: {
+    numberOfBedrooms: 1,
+    numberOfLifts: 0,
+    numberOfLivingRooms: 0,
+    windowType: "DBL",
+    yearConstructed: "0",
+  },
+  patches: undefined,
+};
+
+export const mockEditAssetAddressRequest: EditAssetAddressRequest = {
+  assetAddress: {
+    uprn: "100021045676",
+    addressLine1: "FLAT B",
+    addressLine2: "51 GREENWOOD ROAD",
+    addressLine3: "HACKNEY",
+    addressLine4: "LONDON",
+    postCode: "E8 1NT",
+    postPreamble: "",
+  },
+};

--- a/lib/api/asset/v1/service.test.ts
+++ b/lib/api/asset/v1/service.test.ts
@@ -1,8 +1,12 @@
 import { config } from "@mtfh/common/lib/config";
 import { axiosInstance, useAxiosSWR } from "@mtfh/common/lib/http";
 
+import {
+  mockAsset,
+  mockCreateNewAssetRequest,
+  mockEditAssetAddressRequest,
+} from "./mocks";
 import { createAsset, patchAsset, useAsset } from "./service";
-import { Asset, CreateNewAssetRequest, EditAssetAddressRequest } from "./types";
 
 jest.mock("@mtfh/common/lib/http", () => ({
   ...jest.requireActual("@mtfh/common/lib/http"),
@@ -18,23 +22,12 @@ describe("patchAsset", () => {
   test("it calls the api endpoint with the correct url and parameters", async () => {
     const assetGuid = "15adc44b-6fde-46e8-af9c-e18b1495c9ab";
     const assetVersion = "3";
-    const assetAddress: EditAssetAddressRequest = {
-      assetAddress: {
-        uprn: "100021045676",
-        addressLine1: "FLAT B",
-        addressLine2: "51 GREENWOOD ROAD",
-        addressLine3: "HACKNEY",
-        addressLine4: "LONDON",
-        postCode: "E8 1NT",
-        postPreamble: "",
-      },
-    };
 
-    await patchAsset(assetGuid, assetAddress, assetVersion);
+    await patchAsset(assetGuid, mockEditAssetAddressRequest, assetVersion);
 
     expect(axiosInstance.patch).toBeCalledWith(
       `${config.assetApiUrlV1}/assets/${assetGuid}/address`,
-      assetAddress,
+      mockEditAssetAddressRequest,
       { headers: { "If-Match": assetVersion } },
     );
   });
@@ -42,117 +35,25 @@ describe("patchAsset", () => {
 
 describe("useAsset", () => {
   test("it calls the api endpoint with the correct url and parameters", async () => {
-    const returnedValue: Asset = {
-      id: "15adc44b-6fde-46e8-af9c-e18b1495c9ab",
-      assetId: "100021045676",
-      assetType: "LettableNonDwelling",
-      rootAsset: "",
-      parentAssetIds: "",
-      assetLocation: {
-        floorNo: "4",
-        totalBlockFloors: 6,
-        parentAssets: [{ id: "123", name: "asset", type: "asset-type" }],
-      },
-      assetAddress: {
-        uprn: "100021045676",
-        addressLine1: "FLAT B",
-        addressLine2: "51 GREENWOOD ROAD",
-        addressLine3: "HACKNEY",
-        addressLine4: "LONDON",
-        postCode: "E8 1NT",
-        postPreamble: "",
-      },
-      assetManagement: {
-        agent: "agent",
-        areaOfficeName: "areaOfficeName",
-        isCouncilProperty: true,
-        managingOrganisation: "org",
-        managingOrganisationId: "456",
-        owner: "owner",
-        isTMOManaged: true,
-      },
-      assetCharacteristics: {
-        numberOfBedrooms: 2,
-        numberOfLifts: 1,
-        numberOfLivingRooms: 1,
-        windowType: "DBL",
-        yearConstructed: "2077",
-        numberOfSingleBeds: 1,
-        numberOfDoubleBeds: 1,
-        numberOfFloors: 2,
-        totalBlockFloors: 5,
-        heating: "FCB",
-        propertyFactor: "4.5",
-        architecturalType: "PRE45MR-FLT",
-      },
-      tenure: null,
-      versionNumber: 2,
-      patches: [
-        {
-          id: "bd0a8e2b-c3b5-4628-aa33-8e7509d5eac6",
-          parentId: "8d4fb05d-3ff5-48b7-a17a-71fcb27a66a8",
-          name: "SN4",
-          patchType: "patch",
-          domain: "MMH",
-          responsibleEntities: [],
-        },
-      ],
-    };
     const assetGuid = "15adc44b-6fde-46e8-af9c-e18b1495c9ab";
 
-    (useAxiosSWR as jest.Mock).mockResolvedValueOnce(returnedValue);
+    (useAxiosSWR as jest.Mock).mockResolvedValueOnce(mockAsset);
 
     const response = await useAsset(assetGuid, undefined);
     expect(useAxiosSWR).toBeCalledWith(
       `${config.assetApiUrlV1}/assets/${assetGuid}`,
       undefined,
     );
-    expect(response).toBe(returnedValue);
+    expect(response).toBe(mockAsset);
   });
 });
 
 describe("createAsset", () => {
   test("it calls the api endpoint with the correct url and parameters", async () => {
-    const body: CreateNewAssetRequest = {
-      id: "3f44819f-f3b4-4363-88b6-4575aa4bc5b0",
-      assetId: "1234",
-      parentAssetIds: "",
-      assetType: "Dwelling",
-      isActive: true,
-      assetLocation: {
-        floorNo: "",
-        totalBlockFloors: 0,
-        parentAssets: [],
-      },
-      assetAddress: {
-        uprn: "100023022032",
-        postPreamble: "",
-        addressLine1: "20000 Butfield House Stevens Avenue",
-        addressLine2: "London",
-        addressLine3: "",
-        addressLine4: "",
-        postCode: "E9 6RS",
-      },
-      assetManagement: {
-        agent: "Sanctuary Housing Association",
-        areaOfficeName: "",
-        isCouncilProperty: true,
-        managingOrganisation: "London Borough of Hackney",
-        isTMOManaged: false,
-        managingOrganisationId: "c01e3146-e630-c2cd-e709-18ef57bf3724",
-      },
-      assetCharacteristics: {
-        numberOfBedrooms: 1,
-        numberOfLifts: 0,
-        numberOfLivingRooms: 0,
-        windowType: "DBL",
-        yearConstructed: "0",
-      },
-      patches: undefined,
-    };
-
-    createAsset(body);
-
-    expect(axiosInstance.post).toBeCalledWith(`${config.assetApiUrlV1}/assets/`, body);
+    await createAsset(mockCreateNewAssetRequest);
+    expect(axiosInstance.post).toBeCalledWith(
+      `${config.assetApiUrlV1}/assets/`,
+      mockCreateNewAssetRequest,
+    );
   });
 });

--- a/lib/api/asset/v1/types.ts
+++ b/lib/api/asset/v1/types.ts
@@ -2,10 +2,23 @@ import { Patch } from "@mtfh/common/lib/api/patch/v1/types";
 
 export type AssetType = "Dwelling" | "LettableNonDwelling" | string;
 
+export enum RentGroup {
+  GPS,
+  HGF,
+  HRA,
+  LMW,
+  LSC,
+  RSL,
+  TAG,
+  TAH,
+  TRA,
+}
+
 export interface Asset {
   id: string;
   assetId: string;
   assetType: AssetType;
+  rentGroup: RentGroup;
   assetLocation: AssetLocation;
   assetAddress: AssetAddress;
   assetManagement: AssetManagement;

--- a/lib/api/asset/v1/types.ts
+++ b/lib/api/asset/v1/types.ts
@@ -18,7 +18,7 @@ export interface Asset {
   id: string;
   assetId: string;
   assetType: AssetType;
-  rentGroup: RentGroup;
+  rentGroup: RentGroup | null;
   assetLocation: AssetLocation;
   assetAddress: AssetAddress;
   assetManagement: AssetManagement;

--- a/lib/api/patch/v1/mocks.ts
+++ b/lib/api/patch/v1/mocks.ts
@@ -1,0 +1,16 @@
+import { Patch, ResponsibleEntity } from "./types";
+
+export const mockResponsibilityEntity: ResponsibleEntity = {
+  id: "5f82d558-f2c6-4b1c-95dd-0422ab2b11cd",
+  name: "Charlie Doe",
+  responsibleType: "HousingOfficer",
+};
+
+export const mockPatch: Patch = {
+  id: "2fa90983-94b7-4270-a485-dc42ede5af17",
+  parentId: "bcf2cabe-bccc-4bfd-a10c-2fc6b58e9782",
+  name: "SN4",
+  patchType: "patch",
+  domain: "Housing Management",
+  responsibleEntities: [mockResponsibilityEntity],
+};


### PR DESCRIPTION
## What
Created re-usable and publicly available asset and patch mocks to act as a source of truth for use in tests across the micro-frontends.

Added RentGroup enum as a new attribute for the asset object to match the API response schema.

## Why
This will ease the process of updating the schema for asset mocks used for tests in other frontends, including mtfh-frontend-property, and ensures all tests use the same schema.
An alternative could have been to update the schema in mtfh-test-utils but that solidifies the dependency on that package and greatly increases the difficulty of any future schema updates.

## How
Mocks for asset objects and patches and areas were extracted into mock files and used to build up an asset mock, now referenced in the asset tests here.