### PR TITLE
POH-104 - Add paymentReference to TenureParams

### DIFF
--- a/lib/api/tenure/v1/service.test.ts
+++ b/lib/api/tenure/v1/service.test.ts
@@ -68,6 +68,7 @@ describe("when useTenure is called", () => {
 describe("when addTenure is called", () => {
   test("the request should be sent to the correct URL and the expected response should be returned", async () => {
     const params: AddTenureParams = {
+      paymentReference: "",
       startOfTenureDate: "",
       tenureType: {
         code: "",
@@ -117,6 +118,9 @@ describe("when editTenure is called", () => {
     const params: EditTenureParams = {
       id: "id",
       etag: "",
+      paymentReference: "1234567890",
+      startOfTenureDate: "2021-01-01",
+      endOfTenureDate: "2024-01-01",
     };
     const response = {
       data: {},
@@ -128,6 +132,9 @@ describe("when editTenure is called", () => {
       `${config.tenureApiUrlV1}/tenures/${params.id}`,
       {
         etag: params.etag,
+        paymentReference: params.paymentReference,
+        startOfTenureDate: params.startOfTenureDate,
+        endOfTenureDate: params.endOfTenureDate,
       },
     );
     expect(editTenureResponse).toBe(response.data);

--- a/lib/api/tenure/v1/service.ts
+++ b/lib/api/tenure/v1/service.ts
@@ -17,6 +17,7 @@ export const useTenure = (
 };
 
 export interface TenureParams {
+  paymentReference: string | undefined;
   startOfTenureDate: string;
   endOfTenureDate?: string | null;
   tenureType: TenureType;

--- a/lib/api/tenure/v1/service.ts
+++ b/lib/api/tenure/v1/service.ts
@@ -17,7 +17,7 @@ export const useTenure = (
 };
 
 export interface TenureParams {
-  paymentReference: string | undefined;
+  paymentReference?: string | null;
   startOfTenureDate: string;
   endOfTenureDate?: string | null;
   tenureType: TenureType;


### PR DESCRIPTION
Added `paymentReference`field to `TenureParams` interface for use in the Tenure microfrontend. This allows the Edit Tenure form to include the field

The field will remain disabled on the tenure MFE pending further refinement but still needs this change to the schema in preparation.

Used by the new functionality in the [Tenure MFE PR 100](https://github.com/LBHackney-IT/mtfh-frontend-tenure/pull/100)