### PR TITLE
CreateNewAssetRequest assetLocation.parentAssets type set from "any" to specific type

### DIFF
--- a/lib/api/asset/v1/types.ts
+++ b/lib/api/asset/v1/types.ts
@@ -100,7 +100,7 @@ export interface CreateNewAssetRequest {
   assetLocation: {
     floorNo: string;
     totalBlockFloors: number | null;
-    parentAssets: any[];
+    parentAssets: ParentAsset[];
   };
   assetAddress: {
     uprn: string;


### PR DESCRIPTION
CreateNewAssetRequest assetLocation.parentAssets type was set to `any`. Changed to specific, correct type `ParentAsset[]`.