### PR TITLE
MR-734 - Add validation to CreateNewAsset API call to ensure only one parent asset is in the payload

### DIFF
--- a/lib/api/asset/v1/service.test.ts
+++ b/lib/api/asset/v1/service.test.ts
@@ -90,14 +90,14 @@ describe("when createAsset is called", () => {
     );
   });
 
-  test("the request should fail if the new asset has multiple parent assets", () => {
+  test("the request should fail if the new asset has multiple parent assets", async () => {
     const payloadWithMultipleParents = mockCreateNewAssetRequest;
     payloadWithMultipleParents.assetLocation.parentAssets = [
       { id: "guid123", name: "123 estate", type: "Estate" },
-      { id: "guid456", name: "456 block", type: "Block" }
-    ]
+      { id: "guid456", name: "456 block", type: "Block" },
+    ];
 
     // The error will be thrown even before the POST request is sent
-    expect(createAsset(payloadWithMultipleParents)).rejects.toThrow(Error);
+    await expect(createAsset(payloadWithMultipleParents)).rejects.toThrow(Error);
   });
 });

--- a/lib/api/asset/v1/service.test.ts
+++ b/lib/api/asset/v1/service.test.ts
@@ -89,4 +89,15 @@ describe("when createAsset is called", () => {
       mockCreateNewAssetRequest,
     );
   });
+
+  test("the request should fail if the new asset has multiple parent assets", () => {
+    const payloadWithMultipleParents = mockCreateNewAssetRequest;
+    payloadWithMultipleParents.assetLocation.parentAssets = [
+      { id: "guid123", name: "123 estate", type: "Estate" },
+      { id: "guid456", name: "456 block", type: "Block" }
+    ]
+
+    // The error will be thrown even before the POST request is sent
+    expect(createAsset(payloadWithMultipleParents)).rejects.toThrow(Error);
+  });
 });

--- a/lib/api/asset/v1/service.ts
+++ b/lib/api/asset/v1/service.ts
@@ -93,7 +93,7 @@ export const patchAssetAddress = async (
 export const createAsset = async (request: CreateNewAssetRequest) => {
   if (request.assetLocation?.parentAssets?.length > 1) {
     const error = "Only one parent asset is allowed when creating a new asset.";
-    console.error(error)
+    console.error(error);
     throw new Error(error);
   }
 

--- a/lib/api/asset/v1/service.ts
+++ b/lib/api/asset/v1/service.ts
@@ -91,6 +91,12 @@ export const patchAssetAddress = async (
 };
 
 export const createAsset = async (request: CreateNewAssetRequest) => {
+  if (request.assetLocation?.parentAssets?.length > 1) {
+    const error = "Only one parent asset is allowed when creating a new asset.";
+    console.error(error)
+    throw new Error(error);
+  }
+
   return new Promise<void>((resolve, reject) => {
     axiosInstance
       .post(`${config.assetApiUrlV1}/assets/`, request)


### PR DESCRIPTION
- Add validation to CreateNewAsset API call to ensure only one parent asset is in the payload
- Tested manually in New Asset form by hardcoding 2 parents in assetLocation.parentAsset and it works
- Added test

Related to PR: https://github.com/LBHackney-IT/mtfh-frontend-property/pull/102