### PR TITLE
UseChildAssets - Increase default pageSize

### DIFF
--- a/lib/api/asset/v1/service.ts
+++ b/lib/api/asset/v1/service.ts
@@ -24,12 +24,16 @@ export const useAsset = (
 
 export const useChildAssets = (
   id: string | null,
+  pageSize: number = 5000,
   options?: AxiosSWRConfiguration<GetAssetRelationshipsResponse>,
 ): AxiosSWRResponse<GetAssetRelationshipsResponse> => {
-  return useAxiosSWR(
-    id && `${config.assetSearchApiUrlV1}/search/assetrelationships?searchText=${id}`,
+
+  const response = useAxiosSWR(
+    id && `${config.assetSearchApiUrlV1}/search/assetrelationships?searchText=${id}&pageSize=${pageSize}`,
     options,
   );
+
+  return response
 };
 
 export const getParentAssets = (

--- a/lib/api/asset/v1/service.ts
+++ b/lib/api/asset/v1/service.ts
@@ -15,7 +15,6 @@ import {
   PatchAssetRequest,
 } from "./types";
 
-
 export const getAsset = async (id: string) => {
   return axiosInstance.get<Asset>(`${config.assetApiUrlV1}/assets/${id}`);
 };
@@ -41,8 +40,10 @@ export const useChildAssets = (
   return response;
 };
 
-export const getChildAssets = async (id: string,  pageSize = 5000) => {
-  return axiosInstance.get<Asset>(`${config.assetSearchApiUrlV1}/search/assetrelationships?searchText=${id}&pageSize=${pageSize}`);
+export const getChildAssets = async (id: string, pageSize = 5000) => {
+  return axiosInstance.get<Asset>(
+    `${config.assetSearchApiUrlV1}/search/assetrelationships?searchText=${id}&pageSize=${pageSize}`,
+  );
 };
 
 export const getParentAssets = (

--- a/lib/api/asset/v1/service.ts
+++ b/lib/api/asset/v1/service.ts
@@ -24,16 +24,16 @@ export const useAsset = (
 
 export const useChildAssets = (
   id: string | null,
-  pageSize: number = 5000,
   options?: AxiosSWRConfiguration<GetAssetRelationshipsResponse>,
+  pageSize = 5000,
 ): AxiosSWRResponse<GetAssetRelationshipsResponse> => {
-
   const response = useAxiosSWR(
-    id && `${config.assetSearchApiUrlV1}/search/assetrelationships?searchText=${id}&pageSize=${pageSize}`,
+    id &&
+      `${config.assetSearchApiUrlV1}/search/assetrelationships?searchText=${id}&pageSize=${pageSize}`,
     options,
   );
 
-  return response
+  return response;
 };
 
 export const getParentAssets = (

--- a/lib/api/asset/v1/service.ts
+++ b/lib/api/asset/v1/service.ts
@@ -15,6 +15,11 @@ import {
   PatchAssetRequest,
 } from "./types";
 
+
+export const getAsset = async (id: string) => {
+  return axiosInstance.get<Asset>(`${config.assetApiUrlV1}/assets/${id}`);
+};
+
 export const useAsset = (
   id: string | null,
   options?: AxiosSWRConfiguration<Asset>,
@@ -34,6 +39,10 @@ export const useChildAssets = (
   );
 
   return response;
+};
+
+export const getChildAssets = async (id: string,  pageSize = 5000) => {
+  return axiosInstance.get<Asset>(`${config.assetSearchApiUrlV1}/search/assetrelationships?searchText=${id}&pageSize=${pageSize}`);
 };
 
 export const getParentAssets = (
@@ -71,10 +80,6 @@ export const patchAsset = async (
       "If-Match": assetVersion,
     },
   });
-};
-
-export const getAsset = async (id: string) => {
-  return axiosInstance.get<Asset>(`${config.assetApiUrlV1}/assets/${id}`);
 };
 
 export const patchAssetAddress = async (


### PR DESCRIPTION
## Ticket

[https://hackney.atlassian.net/browse/MR-743?atlOrigin=eyJpIjoiYWNkNzVlYjA5Y2JjNGUxNWJmMzAyNzhmMWFlYTY3OGQiLCJwIjoiaiJ9](https://hackney.atlassian.net/browse/MR-743?atlOrigin=eyJpIjoiYWNkNzVlYjA5Y2JjNGUxNWJmMzAyNzhmMWFlYTY3OGQiLCJwIjoiaiJ9)

## Summary of Changes

- The default pageSize for child assets in the housingSearchAPI is 12. However, many properties have multiple hundred. I have increased the default value to 5000, which is way too high, because that will ensure all childAssets are fetched in a request
- Add getChildAssets endpoint - might be useful