### PR TITLE
MR-757 - Add API request to change Asset Management (required for LBH Ownership edit feature)

### DIFF
--- a/lib/api/asset/v1/mocks.ts
+++ b/lib/api/asset/v1/mocks.ts
@@ -126,16 +126,18 @@ export const mockEditAssetBoilerHouseRequest: PatchAssetBoilerHouseRequest = {
 };
 
 export const mockEditAssetOwnershipRequest: PatchAssetLbhOwnershipRequest = {
-  agent: "Hackney Homes",
-  areaOfficeName: "Homerton (1) Panel Area Team",
-  isCouncilProperty: true,
-  managingOrganisation: "London Borough of Hackney",
-  managingOrganisationId: "c01e3146-e630-c2cd-e709-18ef57bf3724",
-  owner: "LBH",
-  isTMOManaged: false,
-  propertyOccupiedStatus: "OC",
-  isNoRepairsMaintenance: true,
-  councilTaxLiability: "",
-  councilTaxType: "",
-  propertyOccupiedStatusReason: "",
+  assetManagement: {
+    agent: "Hackney Homes",
+    areaOfficeName: "Homerton (1) Panel Area Team",
+    isCouncilProperty: true,
+    managingOrganisation: "London Borough of Hackney",
+    managingOrganisationId: "c01e3146-e630-c2cd-e709-18ef57bf3724",
+    owner: "LBH",
+    isTMOManaged: false,
+    propertyOccupiedStatus: "OC",
+    isNoRepairsMaintenance: true,
+    councilTaxLiability: "",
+    councilTaxType: "",
+    propertyOccupiedStatusReason: ""
+  }
 };

--- a/lib/api/asset/v1/mocks.ts
+++ b/lib/api/asset/v1/mocks.ts
@@ -10,6 +10,7 @@ import {
   EditAssetAddressRequest,
   ParentAsset,
   PatchAssetBoilerHouseRequest,
+  PatchAssetLbhOwnershipRequest,
   RentGroup,
 } from "./types";
 
@@ -120,6 +121,21 @@ export const mockEditAssetAddressRequest: EditAssetAddressRequest = {
   },
 };
 
-export const mockEditAssetRequest: PatchAssetBoilerHouseRequest = {
+export const mockEditAssetBoilerHouseRequest: PatchAssetBoilerHouseRequest = {
   boilerHouseId: "3f44819f-f3b4-4363-88b6-4575aa4bc5b0",
+};
+
+export const mockEditAssetOwnershipRequest: PatchAssetLbhOwnershipRequest = {
+  agent: "Hackney Homes",
+  areaOfficeName: "Homerton (1) Panel Area Team",
+  isCouncilProperty: true,
+  managingOrganisation: "London Borough of Hackney",
+  managingOrganisationId: "c01e3146-e630-c2cd-e709-18ef57bf3724",
+  owner: "LBH",
+  isTMOManaged: false,
+  propertyOccupiedStatus: "OC",
+  isNoRepairsMaintenance: true,
+  councilTaxLiability: "",
+  councilTaxType: "",
+  propertyOccupiedStatusReason: ""
 };

--- a/lib/api/asset/v1/mocks.ts
+++ b/lib/api/asset/v1/mocks.ts
@@ -138,6 +138,6 @@ export const mockEditAssetOwnershipRequest: PatchAssetLbhOwnershipRequest = {
     isNoRepairsMaintenance: true,
     councilTaxLiability: "",
     councilTaxType: "",
-    propertyOccupiedStatusReason: ""
-  }
+    propertyOccupiedStatusReason: "",
+  },
 };

--- a/lib/api/asset/v1/mocks.ts
+++ b/lib/api/asset/v1/mocks.ts
@@ -9,7 +9,7 @@ import {
   CreateNewAssetRequest,
   EditAssetAddressRequest,
   ParentAsset,
-  PatchAssetRequest,
+  PatchAssetBoilerHouseRequest,
   RentGroup,
 } from "./types";
 
@@ -120,6 +120,6 @@ export const mockEditAssetAddressRequest: EditAssetAddressRequest = {
   },
 };
 
-export const mockEditAssetRequest: PatchAssetRequest = {
+export const mockEditAssetRequest: PatchAssetBoilerHouseRequest = {
   boilerHouseId: "3f44819f-f3b4-4363-88b6-4575aa4bc5b0",
 };

--- a/lib/api/asset/v1/mocks.ts
+++ b/lib/api/asset/v1/mocks.ts
@@ -137,5 +137,5 @@ export const mockEditAssetOwnershipRequest: PatchAssetLbhOwnershipRequest = {
   isNoRepairsMaintenance: true,
   councilTaxLiability: "",
   councilTaxType: "",
-  propertyOccupiedStatusReason: ""
+  propertyOccupiedStatusReason: "",
 };

--- a/lib/api/asset/v1/service.test.ts
+++ b/lib/api/asset/v1/service.test.ts
@@ -11,9 +11,8 @@ import {
 import {
   createAsset,
   getAsset,
+  patchAsset,
   patchAssetAddress,
-  patchAssetBoilerHouse,
-  patchAssetOwnership,
   useAsset,
 } from "./service";
 
@@ -28,12 +27,12 @@ jest.mock("@mtfh/common/lib/http", () => ({
   mutate: jest.fn(),
 }));
 
-describe("when patchAssetBoilerHouse is called", () => {
-  test("the request should be sent to the correct URL, with the correct payload and asset GUID as a query parameter", async () => {
+describe("when patchAsset is called", () => {
+  test("Patching Boiler House ID: the request should be sent to the correct URL, with the correct payload and asset GUID as a query parameter", async () => {
     const assetGuid = "15adc44b-6fde-46e8-af9c-e18b1495c9ab";
     const assetVersion = "3";
 
-    await patchAssetBoilerHouse(assetGuid, mockEditAssetBoilerHouseRequest, assetVersion);
+    await patchAsset(assetGuid, mockEditAssetBoilerHouseRequest, assetVersion);
 
     expect(axiosInstance.patch).toBeCalledWith(
       `${config.assetApiUrlV1}/assets/${assetGuid}`,
@@ -41,14 +40,12 @@ describe("when patchAssetBoilerHouse is called", () => {
       { headers: { "If-Match": assetVersion } },
     );
   });
-});
 
-describe("when patchAssetOwnership is called", () => {
-  test("the request should be sent to the correct URL, with the correct payload and asset GUID as a query parameter", async () => {
+  test("Patching Asset Ownership: the request should be sent to the correct URL, with the correct payload and asset GUID as a query parameter", async () => {
     const assetGuid = "15adc44b-6fde-46e8-af9c-e18b1495c9ab";
     const assetVersion = "3";
 
-    await patchAssetOwnership(assetGuid, mockEditAssetOwnershipRequest, assetVersion);
+    await patchAsset(assetGuid, mockEditAssetOwnershipRequest, assetVersion);
 
     expect(axiosInstance.patch).toBeCalledWith(
       `${config.assetApiUrlV1}/assets/${assetGuid}`,

--- a/lib/api/asset/v1/service.test.ts
+++ b/lib/api/asset/v1/service.test.ts
@@ -11,10 +11,10 @@ import {
 import {
   createAsset,
   getAsset,
-  patchAssetBoilerHouse,
   patchAssetAddress,
-  useAsset,
+  patchAssetBoilerHouse,
   patchAssetOwnership,
+  useAsset,
 } from "./service";
 
 jest.mock("@mtfh/common/lib/http", () => ({

--- a/lib/api/asset/v1/service.test.ts
+++ b/lib/api/asset/v1/service.test.ts
@@ -5,14 +5,16 @@ import {
   mockAsset,
   mockCreateNewAssetRequest,
   mockEditAssetAddressRequest,
-  mockEditAssetRequest,
+  mockEditAssetBoilerHouseRequest,
+  mockEditAssetOwnershipRequest,
 } from "./mocks";
 import {
   createAsset,
   getAsset,
-  patchAsset,
+  patchAssetBoilerHouse,
   patchAssetAddress,
   useAsset,
+  patchAssetOwnership,
 } from "./service";
 
 jest.mock("@mtfh/common/lib/http", () => ({
@@ -26,16 +28,31 @@ jest.mock("@mtfh/common/lib/http", () => ({
   mutate: jest.fn(),
 }));
 
-describe("when patchAsset is called", () => {
+describe("when patchAssetBoilerHouse is called", () => {
   test("the request should be sent to the correct URL, with the correct payload and asset GUID as a query parameter", async () => {
     const assetGuid = "15adc44b-6fde-46e8-af9c-e18b1495c9ab";
     const assetVersion = "3";
 
-    await patchAsset(assetGuid, mockEditAssetRequest, assetVersion);
+    await patchAssetBoilerHouse(assetGuid, mockEditAssetBoilerHouseRequest, assetVersion);
 
     expect(axiosInstance.patch).toBeCalledWith(
       `${config.assetApiUrlV1}/assets/${assetGuid}`,
-      mockEditAssetRequest,
+      mockEditAssetBoilerHouseRequest,
+      { headers: { "If-Match": assetVersion } },
+    );
+  });
+});
+
+describe("when patchAssetOwnership is called", () => {
+  test("the request should be sent to the correct URL, with the correct payload and asset GUID as a query parameter", async () => {
+    const assetGuid = "15adc44b-6fde-46e8-af9c-e18b1495c9ab";
+    const assetVersion = "3";
+
+    await patchAssetOwnership(assetGuid, mockEditAssetOwnershipRequest, assetVersion);
+
+    expect(axiosInstance.patch).toBeCalledWith(
+      `${config.assetApiUrlV1}/assets/${assetGuid}`,
+      mockEditAssetOwnershipRequest,
       { headers: { "If-Match": assetVersion } },
     );
   });

--- a/lib/api/asset/v1/service.ts
+++ b/lib/api/asset/v1/service.ts
@@ -72,21 +72,9 @@ export const getParentAssets = (
   return response;
 };
 
-export const patchAssetBoilerHouse = async (
+export const patchAsset = async (
   id: string,
-  request: PatchAssetBoilerHouseRequest,
-  assetVersion: string | null,
-) => {
-  return axiosInstance.patch(`${config.assetApiUrlV1}/assets/${id}`, request, {
-    headers: {
-      "If-Match": assetVersion,
-    },
-  });
-};
-
-export const patchAssetOwnership = async (
-  id: string,
-  request: PatchAssetLbhOwnershipRequest,
+  request: PatchAssetBoilerHouseRequest | PatchAssetLbhOwnershipRequest,
   assetVersion: string | null,
 ) => {
   return axiosInstance.patch(`${config.assetApiUrlV1}/assets/${id}`, request, {

--- a/lib/api/asset/v1/service.ts
+++ b/lib/api/asset/v1/service.ts
@@ -13,6 +13,7 @@ import {
   GetAssetParentsResponse,
   GetAssetRelationshipsResponse,
   PatchAssetBoilerHouseRequest,
+  PatchAssetLbhOwnershipRequest,
 } from "./types";
 
 export const getAsset = async (id: string) => {
@@ -71,9 +72,21 @@ export const getParentAssets = (
   return response;
 };
 
-export const patchAsset = async (
+export const patchAssetBoilerHouse = async (
   id: string,
   request: PatchAssetBoilerHouseRequest,
+  assetVersion: string | null,
+) => {
+  return axiosInstance.patch(`${config.assetApiUrlV1}/assets/${id}`, request, {
+    headers: {
+      "If-Match": assetVersion,
+    },
+  });
+};
+
+export const patchAssetOwnership = async (
+  id: string,
+  request: PatchAssetLbhOwnershipRequest,
   assetVersion: string | null,
 ) => {
   return axiosInstance.patch(`${config.assetApiUrlV1}/assets/${id}`, request, {

--- a/lib/api/asset/v1/service.ts
+++ b/lib/api/asset/v1/service.ts
@@ -12,7 +12,7 @@ import {
   EditAssetAddressRequest,
   GetAssetParentsResponse,
   GetAssetRelationshipsResponse,
-  PatchAssetRequest,
+  PatchAssetBoilerHouseRequest,
 } from "./types";
 
 export const getAsset = async (id: string) => {
@@ -73,7 +73,7 @@ export const getParentAssets = (
 
 export const patchAsset = async (
   id: string,
-  request: PatchAssetRequest,
+  request: PatchAssetBoilerHouseRequest,
   assetVersion: string | null,
 ) => {
   return axiosInstance.patch(`${config.assetApiUrlV1}/assets/${id}`, request, {

--- a/lib/api/asset/v1/types.ts
+++ b/lib/api/asset/v1/types.ts
@@ -138,6 +138,23 @@ export interface GetAssetParentsResponse {
   parentAssets: Asset[];
 }
 
-export interface PatchAssetRequest {
+export interface PatchAssetBoilerHouseRequest {
   boilerHouseId: string;
+}
+
+export interface PatchAssetLbhOwnershipRequest {
+  agent: string;
+  areaOfficeName: string;
+  isCouncilProperty: boolean;
+  managingOrganisation: string;
+  managingOrganisationId: string;
+  owner: string;
+  isTMOManaged: boolean;
+  propertyOccupiedStatus: string;
+  propertyOccupiedStatusReason: string;
+  isNoRepairsMaintenance?: boolean;
+  councilTaxType: string;
+  councilTaxLiability: string;
+  isTemporaryAccomodation?: boolean;
+  readyToLetDate?: boolean;
 }

--- a/lib/api/asset/v1/types.ts
+++ b/lib/api/asset/v1/types.ts
@@ -61,6 +61,13 @@ export interface AssetManagement {
   managingOrganisationId: string;
   owner: string;
   isTMOManaged: boolean;
+  propertyOccupiedStatus?: string;
+  propertyOccupiedStatusReason?: string;
+  isNoRepairsMaintenance?: boolean;
+  councilTaxType?: string;
+  councilTaxLiability?: string;
+  isTemporaryAccomodation?: boolean;
+  readyToLetDate?: boolean;
 }
 
 export interface AssetCharacteristics {
@@ -143,18 +150,5 @@ export interface PatchAssetBoilerHouseRequest {
 }
 
 export interface PatchAssetLbhOwnershipRequest {
-  agent: string;
-  areaOfficeName: string;
-  isCouncilProperty: boolean;
-  managingOrganisation: string;
-  managingOrganisationId: string;
-  owner: string;
-  isTMOManaged: boolean;
-  propertyOccupiedStatus: string;
-  propertyOccupiedStatusReason: string;
-  isNoRepairsMaintenance?: boolean;
-  councilTaxType: string;
-  councilTaxLiability: string;
-  isTemporaryAccomodation?: boolean;
-  readyToLetDate?: boolean;
+  assetManagement: AssetManagement;
 }


### PR DESCRIPTION
Prior to merging this PR/as of now, `patchAsset` is only set up for editing the `boilerHouseId` of an asset (I have checked the other repos to make sure there are no other MFE referencing this method, other than Common and Property - [Github references](https://github.com/search?q=org%3ALBHackney-IT%20patchasset&type=code))

This PR enables patchAsset to accept a new type of request, to change asset ownership (`isCouncilProperty` field).

Changes:
- Renamed `PatchAssetRequest` interface to `PatchAssetBoilerHouseRequest`, more specific. 
- Added `PatchAssetLbhOwnershipRequest` interface, to be used when editing asset ownership.
- Updated AssetManagement interface to be aligned with its [counterpart class in Asset Shared](https://github.com/LBHackney-IT/asset-shared/blob/main/Hackney.Shared.Asset/Domain/AssetManagement.cs) (v 0.37 - latest). To avoid any potential errors, I've only added the remaining fields (that some asset may or may not have) as optional.
- `patchAsset` now can accepts requests/parameters of type PatchAssetBoilerHouseRequest or PatchAssetLbhOwnershipRequest
- Added test for this new request type (`PatchAssetLbhOwnershipRequest`) and mock request object.

Manually tested with Postman and via the MMH front-end the following:
- add boiler house ID
- remove boiler house ID
- changed `isCouncilProperty` (from development branch of Property - [see related PR](https://github.com/LBHackney-IT/mtfh-frontend-property/pull/110))
- checked that, when changing the `isCouncilProperty` field, only this field of the asset and the asset version are changed, and made sure other fields are not affected/lost.