### PR TITLE
Add patches and areas API endpoints (delete responsibleEntitity, append responsibleEntity, replace responsibleEntities)

### DIFF
--- a/lib/api/patch/v1/mocks.ts
+++ b/lib/api/patch/v1/mocks.ts
@@ -1,4 +1,4 @@
-import { Patch, ResponsibleEntity } from "./types";
+import { Patch, ResponsibleEntity, UpdatePatchesAndAreasRequest } from "./types";
 
 export const mockResponsibilityEntity: ResponsibleEntity = {
   id: "5f82d558-f2c6-4b1c-95dd-0422ab2b11cd",
@@ -13,4 +13,11 @@ export const mockPatch: Patch = {
   patchType: "patch",
   domain: "Housing Management",
   responsibleEntities: [mockResponsibilityEntity],
+  versionNumber: 3,
+};
+
+export const mockUpdatePatchesAndAreasRequest: UpdatePatchesAndAreasRequest = {
+  id: "5f82d558-f2c6-4b1c-95dd-0422ab2b11cd",
+  name: "Jane Doe",
+  responsibleType: "HousingOfficer",
 };

--- a/lib/api/patch/v1/mocks.ts
+++ b/lib/api/patch/v1/mocks.ts
@@ -1,14 +1,9 @@
-import {
-  Patch,
-  ResponsibleEntity,
-  ResponsibleType,
-  UpdatePatchesAndAreasRequest,
-} from "./types";
+import { Patch, ResponsibleEntity, UpdatePatchesAndAreasRequest } from "./types";
 
 export const mockResponsibilityEntity: ResponsibleEntity = {
   id: "5f82d558-f2c6-4b1c-95dd-0422ab2b11cd",
   name: "Charlie Doe",
-  responsibleType: ResponsibleType.HousingOfficer,
+  responsibleType: "HousingOfficer",
 };
 
 export const mockPatch: Patch = {
@@ -24,5 +19,5 @@ export const mockPatch: Patch = {
 export const mockUpdatePatchesAndAreasRequest: UpdatePatchesAndAreasRequest = {
   id: "5f82d558-f2c6-4b1c-95dd-0422ab2b11cd",
   name: "Jane Doe",
-  responsibleType: ResponsibleType.HousingOfficer,
+  responsibleType: "HousingOfficer",
 };

--- a/lib/api/patch/v1/mocks.ts
+++ b/lib/api/patch/v1/mocks.ts
@@ -1,9 +1,14 @@
-import { Patch, ResponsibleEntity, UpdatePatchesAndAreasRequest } from "./types";
+import {
+  Patch,
+  ResponsibleEntity,
+  ResponsibleType,
+  UpdatePatchesAndAreasRequest,
+} from "./types";
 
 export const mockResponsibilityEntity: ResponsibleEntity = {
   id: "5f82d558-f2c6-4b1c-95dd-0422ab2b11cd",
   name: "Charlie Doe",
-  responsibleType: "HousingOfficer",
+  responsibleType: ResponsibleType.HousingOfficer,
 };
 
 export const mockPatch: Patch = {
@@ -19,5 +24,5 @@ export const mockPatch: Patch = {
 export const mockUpdatePatchesAndAreasRequest: UpdatePatchesAndAreasRequest = {
   id: "5f82d558-f2c6-4b1c-95dd-0422ab2b11cd",
   name: "Jane Doe",
-  responsibleType: "HousingOfficer",
+  responsibleType: ResponsibleType.HousingOfficer,
 };

--- a/lib/api/patch/v1/service.test.ts
+++ b/lib/api/patch/v1/service.test.ts
@@ -6,7 +6,9 @@ import {
   addResponsibleEntityToPatch,
   deletePatchesAndAreasResponsibilities,
   getAllPatchesAndAreas,
+  replacePatchResponsibleEntities,
 } from "./service";
+import { ResponsibleEntity } from "./types";
 
 jest.mock("@mtfh/common/lib/http", () => ({
   ...jest.requireActual("@mtfh/common/lib/http"),
@@ -60,6 +62,25 @@ describe("when deletePatchesAndAreasResponsibilities is called", () => {
 
     expect(axiosInstance.delete).toBeCalledWith(
       `${config.patchesAndAreasApiUrlV1}/patch/${patchId}/responsibleEntity/${responsibleEntityId}`,
+    );
+  });
+});
+
+describe("when replacePatchResponsibleEntities is called", () => {
+  test("the request should be sent to the correct URL with the expected headers and request object", async () => {
+    const patchId = "2fa90983-94b7-4270-a485-dc42ede5af17";
+    const patchVersion = 3;
+
+    await replacePatchResponsibleEntities(
+      patchId,
+      [mockUpdatePatchesAndAreasRequest as ResponsibleEntity],
+      patchVersion,
+    );
+
+    expect(axiosInstance.patch).toBeCalledWith(
+      `${config.patchesAndAreasApiUrlV1}/patch/${patchId}/responsibleEntities`,
+      [mockUpdatePatchesAndAreasRequest],
+      { headers: { "If-Match": `"${patchVersion}"` } },
     );
   });
 });

--- a/lib/api/patch/v1/service.test.ts
+++ b/lib/api/patch/v1/service.test.ts
@@ -13,6 +13,7 @@ jest.mock("@mtfh/common/lib/http", () => ({
   axiosInstance: {
     patch: jest.fn().mockImplementation(() => Promise.resolve({ data: [] })),
     get: jest.fn().mockImplementation(() => Promise.resolve({ data: [] })),
+    delete: jest.fn() 
   },
   useAxiosSWR: jest.fn(),
   mutate: jest.fn(),
@@ -55,7 +56,7 @@ describe("when deletePatchesAndAreasResponsibilities is called", () => {
     const patchId = "2fa90983-94b7-4270-a485-dc42ede5af17";
     const responsibleEntityId = "5f82d558-f2c6-4b1c-95dd-0422ab2b11cd";
 
-    await deletePatchesAndAreasResponsibilities(patchId, responsibleEntityId);
+    deletePatchesAndAreasResponsibilities(patchId, responsibleEntityId);
 
     expect(axiosInstance.delete).toBeCalledWith(
       `${config.patchesAndAreasApiUrlV1}/patch/${patchId}/responsibleEntity/${responsibleEntityId}`,

--- a/lib/api/patch/v1/service.test.ts
+++ b/lib/api/patch/v1/service.test.ts
@@ -1,11 +1,17 @@
 import { config } from "@mtfh/common/lib/config";
 import { axiosInstance } from "@mtfh/common/lib/http";
 
-import { getAllPatchesAndAreas } from "./service";
+import {
+  getAllPatchesAndAreas,
+  addResponsibleEntityToPatch,
+  deletePatchesAndAreasResponsibilities,
+} from "./service";
+import { mockUpdatePatchesAndAreasRequest } from "./mocks";
 
 jest.mock("@mtfh/common/lib/http", () => ({
   ...jest.requireActual("@mtfh/common/lib/http"),
   axiosInstance: {
+    patch: jest.fn().mockImplementation(() => Promise.resolve({ data: [] })),
     get: jest.fn().mockImplementation(() => Promise.resolve({ data: [] })),
   },
   useAxiosSWR: jest.fn(),
@@ -19,6 +25,40 @@ describe("when getAllPatchesAndAreas is called", () => {
     expect(axiosInstance.get).toBeCalledWith(
       `${config.patchesAndAreasApiUrlV1}/patch/all`,
       { headers: { "skip-x-correlation-id": true } },
+    );
+  });
+});
+
+describe("when addResponsibleEntityToPatch is called", () => {
+  test("the request should be sent to the correct URL with the expected headers and request", async () => {
+    const patchId = "2fa90983-94b7-4270-a485-dc42ede5af17";
+    const responsibleEntityId = "5f82d558-f2c6-4b1c-95dd-0422ab2b11cd";
+    const patchVersion = "3";
+
+    await addResponsibleEntityToPatch(
+      patchId,
+      responsibleEntityId,
+      mockUpdatePatchesAndAreasRequest,
+      patchVersion,
+    );
+
+    expect(axiosInstance.patch).toBeCalledWith(
+      `${config.patchesAndAreasApiUrlV1}/patch/${patchId}/responsibleEntity/${responsibleEntityId}`,
+      mockUpdatePatchesAndAreasRequest,
+      { headers: { "If-Match": patchVersion } },
+    );
+  });
+});
+
+describe("when deletePatchesAndAreasResponsibilities is called", () => {
+  test("the request should be sent to the correct URL with the expected headers and request", async () => {
+    const patchId = "2fa90983-94b7-4270-a485-dc42ede5af17";
+    const responsibleEntityId = "5f82d558-f2c6-4b1c-95dd-0422ab2b11cd";
+
+    await deletePatchesAndAreasResponsibilities(patchId, responsibleEntityId);
+
+    expect(axiosInstance.delete).toBeCalledWith(
+      `${config.patchesAndAreasApiUrlV1}/patch/${patchId}/responsibleEntity/${responsibleEntityId}`,
     );
   });
 });

--- a/lib/api/patch/v1/service.test.ts
+++ b/lib/api/patch/v1/service.test.ts
@@ -1,12 +1,12 @@
 import { config } from "@mtfh/common/lib/config";
 import { axiosInstance } from "@mtfh/common/lib/http";
 
+import { mockUpdatePatchesAndAreasRequest } from "./mocks";
 import {
-  getAllPatchesAndAreas,
   addResponsibleEntityToPatch,
   deletePatchesAndAreasResponsibilities,
+  getAllPatchesAndAreas,
 } from "./service";
-import { mockUpdatePatchesAndAreasRequest } from "./mocks";
 
 jest.mock("@mtfh/common/lib/http", () => ({
   ...jest.requireActual("@mtfh/common/lib/http"),

--- a/lib/api/patch/v1/service.test.ts
+++ b/lib/api/patch/v1/service.test.ts
@@ -13,8 +13,9 @@ import { ResponsibleEntity } from "./types";
 jest.mock("@mtfh/common/lib/http", () => ({
   ...jest.requireActual("@mtfh/common/lib/http"),
   axiosInstance: {
-    patch: jest.fn().mockImplementation(() => Promise.resolve({ data: [] })),
     get: jest.fn().mockImplementation(() => Promise.resolve({ data: [] })),
+    put: jest.fn(),
+    patch: jest.fn(),
     delete: jest.fn(),
   },
   useAxiosSWR: jest.fn(),
@@ -77,7 +78,7 @@ describe("when replacePatchResponsibleEntities is called", () => {
       patchVersion,
     );
 
-    expect(axiosInstance.patch).toBeCalledWith(
+    expect(axiosInstance.put).toBeCalledWith(
       `${config.patchesAndAreasApiUrlV1}/patch/${patchId}/responsibleEntities`,
       [mockUpdatePatchesAndAreasRequest],
       { headers: { "If-Match": `"${patchVersion}"` } },

--- a/lib/api/patch/v1/service.test.ts
+++ b/lib/api/patch/v1/service.test.ts
@@ -13,7 +13,7 @@ jest.mock("@mtfh/common/lib/http", () => ({
   axiosInstance: {
     patch: jest.fn().mockImplementation(() => Promise.resolve({ data: [] })),
     get: jest.fn().mockImplementation(() => Promise.resolve({ data: [] })),
-    delete: jest.fn() 
+    delete: jest.fn(),
   },
   useAxiosSWR: jest.fn(),
   mutate: jest.fn(),

--- a/lib/api/patch/v1/service.ts
+++ b/lib/api/patch/v1/service.ts
@@ -1,7 +1,9 @@
+import { AxiosResponse } from "axios";
+
 import { config } from "@mtfh/common/lib/config";
 import { axiosInstance } from "@mtfh/common/lib/http";
 
-import { Patch, UpdatePatchesAndAreasRequest } from "./types";
+import { Patch, ResponsibleEntity, UpdatePatchesAndAreasRequest } from "./types";
 
 export const getAllPatchesAndAreas = async (): Promise<Array<Patch>> => {
   return new Promise<Array<Patch>>((resolve, reject) => {
@@ -37,4 +39,23 @@ export const deletePatchesAndAreasResponsibilities = async (
   await axiosInstance.delete(
     `${config.patchesAndAreasApiUrlV1}/patch/${patchId}/responsibleEntity/${responsibleEntityId}`,
   );
+};
+
+/**
+ * Replaces all the responsible entities for a patch as set in the request
+ * @param patchId - ID of patch object
+ * @param entities - List of people assigned to the patch as responsible entities
+ * @param patchVersion - Version of the patch object (from database)
+ * @returns Promise with 204 No Content on success
+ */
+export const replacePatchResponsibleEntities = async (
+  patchId: string,
+  entities: ResponsibleEntity[],
+  patchVersion: number,
+): Promise<AxiosResponse> => {
+  const apiUrl = `${config.patchesAndAreasApiUrlV1}/patch/${patchId}/responsibleEntities`;
+  const headers = {
+    "If-Match": `"${patchVersion}"`,
+  };
+  return axiosInstance.patch(apiUrl, entities, { headers });
 };

--- a/lib/api/patch/v1/service.ts
+++ b/lib/api/patch/v1/service.ts
@@ -1,7 +1,7 @@
 import { config } from "@mtfh/common/lib/config";
 import { axiosInstance } from "@mtfh/common/lib/http";
 
-import { Patch } from "./types";
+import { Patch, UpdatePatchesAndAreasRequest } from "./types";
 
 export const getAllPatchesAndAreas = async (): Promise<Array<Patch>> => {
   return new Promise<Array<Patch>>((resolve, reject) => {
@@ -12,6 +12,37 @@ export const getAllPatchesAndAreas = async (): Promise<Array<Patch>> => {
         },
       })
       .then((res) => resolve(res.data))
+      .catch((error) => reject(error));
+  });
+};
+
+export const addResponsibleEntityToPatch = async (
+  patchId: string,
+  responsibleEntityId: string,
+  request: UpdatePatchesAndAreasRequest,
+  patchVersion: string | null,
+): Promise<null> => {
+  return new Promise((resolve, reject) => {
+    const apiUrl = `${config.patchesAndAreasApiUrlV1}/patch/${patchId}/responsibleEntity/${responsibleEntityId}`;
+    console.log(`PATCH VERSION: ${patchVersion}`);
+    const headers = { "If-Match": `"${patchVersion}"` };
+    axiosInstance
+      .patch(apiUrl, request, { headers })
+      .then((res) => console.log(res))
+      .catch((error) => reject(error));
+  });
+};
+
+export const deletePatchesAndAreasResponsibilities = async (
+  patchId: string,
+  responsibleEntityId: string,
+): Promise<null> => {
+  return new Promise((resolve, reject) => {
+    axiosInstance
+      .delete(
+        `${config.patchesAndAreasApiUrlV1}/patch/${patchId}/responsibleEntity/${responsibleEntityId}`,
+      )
+      .then((res) => console.log(res))
       .catch((error) => reject(error));
   });
 };

--- a/lib/api/patch/v1/service.ts
+++ b/lib/api/patch/v1/service.ts
@@ -22,12 +22,12 @@ export const addResponsibleEntityToPatch = async (
   request: UpdatePatchesAndAreasRequest,
   patchVersion: string | null,
 ) => {
-    const apiUrl = `${config.patchesAndAreasApiUrlV1}/patch/${patchId}/responsibleEntity/${responsibleEntityId}`;
-     return axiosInstance.patch(apiUrl, request, {
-      headers: {
-        "If-Match": patchVersion,
-      },
-    });
+  const apiUrl = `${config.patchesAndAreasApiUrlV1}/patch/${patchId}/responsibleEntity/${responsibleEntityId}`;
+  return axiosInstance.patch(apiUrl, request, {
+    headers: {
+      "If-Match": patchVersion,
+    },
+  });
 };
 
 export const deletePatchesAndAreasResponsibilities = async (

--- a/lib/api/patch/v1/service.ts
+++ b/lib/api/patch/v1/service.ts
@@ -21,28 +21,19 @@ export const addResponsibleEntityToPatch = async (
   responsibleEntityId: string,
   request: UpdatePatchesAndAreasRequest,
   patchVersion: string | null,
-): Promise<null> => {
-  return new Promise((resolve, reject) => {
+) => {
     const apiUrl = `${config.patchesAndAreasApiUrlV1}/patch/${patchId}/responsibleEntity/${responsibleEntityId}`;
-    console.log(`PATCH VERSION: ${patchVersion}`);
-    const headers = { "If-Match": `"${patchVersion}"` };
-    axiosInstance
-      .patch(apiUrl, request, { headers })
-      .then((res) => console.log(res))
-      .catch((error) => reject(error));
-  });
+     return axiosInstance.patch(apiUrl, request, {
+      headers: {
+        "If-Match": patchVersion,
+      },
+    });
 };
 
 export const deletePatchesAndAreasResponsibilities = async (
   patchId: string,
   responsibleEntityId: string,
-): Promise<null> => {
-  return new Promise((resolve, reject) => {
-    axiosInstance
-      .delete(
-        `${config.patchesAndAreasApiUrlV1}/patch/${patchId}/responsibleEntity/${responsibleEntityId}`,
-      )
-      .then((res) => console.log(res))
-      .catch((error) => reject(error));
-  });
+) => {
+  const apiUrl = `${config.patchesAndAreasApiUrlV1}/patch/${patchId}/responsibleEntity/${responsibleEntityId}`;
+  return axiosInstance.delete(apiUrl);
 };

--- a/lib/api/patch/v1/service.ts
+++ b/lib/api/patch/v1/service.ts
@@ -42,20 +42,20 @@ export const deletePatchesAndAreasResponsibilities = async (
 };
 
 /**
- * Replaces all the responsible entities for a patch as set in the request
- * @param patchId - ID of patch object
- * @param entities - List of people assigned to the patch as responsible entities
- * @param patchVersion - Version of the patch object (from database)
+ * Replaces all the responsible entities for a Patch as set in the request
+ * @param patchId - ID of Patch object
+ * @param entities - List of people assigned to the Patch as responsible entities
+ * @param versionNumber - Version of the patch object (from database)
  * @returns Promise with 204 No Content on success
  */
 export const replacePatchResponsibleEntities = async (
   patchId: string,
   entities: ResponsibleEntity[],
-  patchVersion: number,
+  versionNumber: number,
 ): Promise<AxiosResponse> => {
   const apiUrl = `${config.patchesAndAreasApiUrlV1}/patch/${patchId}/responsibleEntities`;
   const headers = {
-    "If-Match": `"${patchVersion}"`,
+    "If-Match": `"${versionNumber}"`,
   };
-  return axiosInstance.patch(apiUrl, entities, { headers });
+  return axiosInstance.put(apiUrl, entities, { headers });
 };

--- a/lib/api/patch/v1/service.ts
+++ b/lib/api/patch/v1/service.ts
@@ -33,7 +33,8 @@ export const addResponsibleEntityToPatch = async (
 export const deletePatchesAndAreasResponsibilities = async (
   patchId: string,
   responsibleEntityId: string,
-) => {
-  const apiUrl = `${config.patchesAndAreasApiUrlV1}/patch/${patchId}/responsibleEntity/${responsibleEntityId}`;
-  return axiosInstance.delete(apiUrl);
+): Promise<void> => {
+  await axiosInstance.delete(
+    `${config.patchesAndAreasApiUrlV1}/patch/${patchId}/responsibleEntity/${responsibleEntityId}`,
+  );
 };

--- a/lib/api/patch/v1/types.ts
+++ b/lib/api/patch/v1/types.ts
@@ -11,4 +11,11 @@ export interface Patch {
   patchType: string;
   domain: string;
   responsibleEntities: ResponsibleEntity[];
+  versionNumber?: number;
+}
+
+export interface UpdatePatchesAndAreasRequest {
+  id: string;
+  name: string;
+  responsibleType: string;
 }

--- a/lib/api/patch/v1/types.ts
+++ b/lib/api/patch/v1/types.ts
@@ -1,7 +1,12 @@
+export enum ResponsibleType {
+  HousingOfficer,
+  HousingAreaManager,
+}
+
 export interface ResponsibleEntity {
   id: string;
   name: string;
-  responsibleType: string;
+  responsibleType: ResponsibleType;
 }
 
 export interface Patch {
@@ -17,5 +22,5 @@ export interface Patch {
 export interface UpdatePatchesAndAreasRequest {
   id: string;
   name: string;
-  responsibleType: string;
+  responsibleType: ResponsibleType;
 }

--- a/lib/api/patch/v1/types.ts
+++ b/lib/api/patch/v1/types.ts
@@ -1,12 +1,7 @@
-export enum ResponsibleType {
-  HousingOfficer,
-  HousingAreaManager,
-}
-
 export interface ResponsibleEntity {
   id: string;
   name: string;
-  responsibleType: ResponsibleType;
+  responsibleType: string;
 }
 
 export interface Patch {
@@ -22,5 +17,5 @@ export interface Patch {
 export interface UpdatePatchesAndAreasRequest {
   id: string;
   name: string;
-  responsibleType: ResponsibleType;
+  responsibleType: string;
 }


### PR DESCRIPTION
## [MR-764](https://hackney.atlassian.net/jira/software/c/projects/MR/boards/88?selectedIssue=MR-764) As a MMH User I need to be able to identify what housing officer belongs to what patch

Note: A responsible entity refers to a housing officer or housing area manager responsible for a patch or an area (collection of patches)

This adds support for these endpoints of the Patches and Areas API:
1. `addResponsibleEntityToPatch`
PATCH /patch/${patchId}/responsibleEntity/${responsibleEntityId}
Adds a responsible entity to the list of responsible entities for a patch/area

2. `deletePatchesAndAreasResponsibilities`
DELETE /patch/${patchId}/responsibleEntity/${responsibleEntityId}
Removes a responsible entity from the list of responsible entities for a patch/area

3. `replacePatchResponsibleEntities`
PUT /patch/${patchId}/responsibleEntities`
Replaces the current list of a patch or area's responsible entities with a new list with all relevant data needed

`replacePatchResponsibleEntities` will be used to create a feature to allow users to manage the people assigned to a patch


[MR-764]: https://hackney.atlassian.net/browse/MR-764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ