### PR TITLE
get patch or area synchronously

### DIFF
--- a/lib/api/patch/v1/service.test.ts
+++ b/lib/api/patch/v1/service.test.ts
@@ -1,13 +1,13 @@
 import { config } from "@mtfh/common/lib/config";
-import { axiosInstance } from "@mtfh/common/lib/http";
+import { axiosInstance, useAxiosSWR } from "@mtfh/common/lib/http";
 
 import { mockUpdatePatchesAndAreasRequest } from "./mocks";
 import {
   addResponsibleEntityToPatch,
   deletePatchesAndAreasResponsibilities,
   getAllPatchesAndAreas,
-  getPatchOrAreaById,
   replacePatchResponsibleEntities,
+  usePatchOrArea,
 } from "./service";
 import { ResponsibleEntity } from "./types";
 
@@ -35,13 +35,13 @@ describe("when getAllPatchesAndAreas is called", () => {
 });
 
 describe("when get patch or area by id is called", () => {
-  test("the request should be sent to the correct URL with the expected headers", async () => {
+  test("the request should be sent to the correct URL", async () => {
     const patchId = "2fa90983-94b7-4270-a485-dc42ede5af17";
-    await getPatchOrAreaById(patchId);
+    await usePatchOrArea(patchId);
 
-    expect(axiosInstance.get).toBeCalledWith(
+    expect(useAxiosSWR).toBeCalledWith(
       `${config.patchesAndAreasApiUrlV1}/patch/${patchId}`,
-      { headers: { "skip-x-correlation-id": true } },
+      undefined,
     );
   });
 });

--- a/lib/api/patch/v1/service.ts
+++ b/lib/api/patch/v1/service.ts
@@ -1,7 +1,12 @@
 import { AxiosResponse } from "axios";
 
 import { config } from "@mtfh/common/lib/config";
-import { axiosInstance } from "@mtfh/common/lib/http";
+import {
+  AxiosSWRConfiguration,
+  AxiosSWRResponse,
+  axiosInstance,
+  useAxiosSWR,
+} from "@mtfh/common/lib/http";
 
 import { Patch, ResponsibleEntity, UpdatePatchesAndAreasRequest } from "./types";
 
@@ -18,17 +23,11 @@ export const getAllPatchesAndAreas = async (): Promise<Array<Patch>> => {
   });
 };
 
-export const getPatchOrAreaById = async (patchId: string): Promise<Patch> => {
-  return new Promise<Patch>((resolve, reject) => {
-    axiosInstance
-      .get<Patch>(`${config.patchesAndAreasApiUrlV1}/patch/${patchId}`, {
-        headers: {
-          "skip-x-correlation-id": true,
-        },
-      })
-      .then((res) => resolve(res.data))
-      .catch((error) => reject(error));
-  });
+export const usePatchOrArea = (
+  patchId: string,
+  options?: AxiosSWRConfiguration<Patch>,
+): AxiosSWRResponse<Patch> => {
+  return useAxiosSWR(`${config.patchesAndAreasApiUrlV1}/patch/${patchId}`, options);
 };
 
 export const addResponsibleEntityToPatch = async (


### PR DESCRIPTION
Returning a promise adds unnecessary complexity