### PR TITLE
Add an optional `rentGroup` field to the `CreateNewAssetRequest` model.

### DIFF
--- a/lib/api/asset/v1/mocks.ts
+++ b/lib/api/asset/v1/mocks.ts
@@ -96,6 +96,7 @@ export const mockCreateNewAssetRequest: CreateNewAssetRequest = {
   patchId: "acde55f5-6b2c-4d2e-9a74-c0cd78b55ec1",
   parentAssetIds: "",
   assetType: "Dwelling",
+  rentGroup: RentGroup.HRA,
   isActive: true,
   assetLocation: mockAssetLocation,
   assetAddress: mockAssetAddress,

--- a/lib/api/asset/v1/types.ts
+++ b/lib/api/asset/v1/types.ts
@@ -103,6 +103,7 @@ export interface CreateNewAssetRequest {
   areaId?: string;
   patchId?: string;
   assetType: string;
+  rentGroup: RentGroup | undefined | null;
   isActive: boolean;
   parentAssetIds: string;
   assetLocation: {

--- a/lib/api/asset/v1/types.ts
+++ b/lib/api/asset/v1/types.ts
@@ -103,7 +103,7 @@ export interface CreateNewAssetRequest {
   areaId?: string;
   patchId?: string;
   assetType: string;
-  rentGroup?: RentGroup | undefined | null;
+  rentGroup?: RentGroup | null;
   isActive: boolean;
   parentAssetIds: string;
   assetLocation: {

--- a/lib/api/asset/v1/types.ts
+++ b/lib/api/asset/v1/types.ts
@@ -103,7 +103,7 @@ export interface CreateNewAssetRequest {
   areaId?: string;
   patchId?: string;
   assetType: string;
-  rentGroup: RentGroup | undefined | null;
+  rentGroup?: RentGroup | undefined | null;
   isActive: boolean;
   parentAssetIds: string;
   assetLocation: {

--- a/lib/api/asset/v1/types.ts
+++ b/lib/api/asset/v1/types.ts
@@ -18,7 +18,7 @@ export interface Asset {
   areaId: string;
   assetId: string;
   assetType: AssetType;
-  rentGroup: RentGroup | null;
+  rentGroup: RentGroup | undefined | null;
   assetLocation: AssetLocation;
   assetAddress: AssetAddress;
   assetManagement: AssetManagement;

--- a/lib/api/asset/v1/types.ts
+++ b/lib/api/asset/v1/types.ts
@@ -18,7 +18,7 @@ export interface Asset {
   areaId: string;
   assetId: string;
   assetType: AssetType;
-  rentGroup: RentGroup | undefined | null;
+  rentGroup?: RentGroup | null;
   assetLocation: AssetLocation;
   assetAddress: AssetAddress;
   assetManagement: AssetManagement;

--- a/lib/api/asset/v1/types.ts
+++ b/lib/api/asset/v1/types.ts
@@ -1,15 +1,15 @@
 export type AssetType = "Dwelling" | "LettableNonDwelling" | string;
 
 export enum RentGroup {
-  GPS,
-  HGF,
-  HRA,
-  LMW,
-  LSC,
-  RSL,
-  TAG,
-  TAH,
-  TRA,
+  GPS = "GPS",
+  HGF = "HGF",
+  HRA = "HRA",
+  LMW = "LMW",
+  LSC = "LSC",
+  RSL = "RSL",
+  TAG = "TAG",
+  TAH = "TAH",
+  TRA = "TRA",
 }
 
 export interface Asset {


### PR DESCRIPTION
# What:
 - Add a `rentGroup` field to the `CreateNewAssetRequest`.
 - Convert the `RentGroup` enum from numeric enum to string enum.
 - Make the `rentGroup` field optional within the `Asset` model.

# Why:
 - This field is needed for capturing the optional Rent Group information upon Asset's creation. Read more details on the linked pull request for `mtfh-microfrontend-property` repository [TODO: link the soon to come PR once created].
 - Made the `RentGroup` enum a string enum to avoid unintended behaviours during its type conversions going forward.
 - Not all assets are meant to have `rentGroup` information, so it makes sense to explicitly reflect that within the model.

# Notes:
 - I don't think the `rentGroup` field or the `RentGroup` enum type has been used anywhere yet. It has merely been put in place as a tag-along during our previous `AssetCharacteristics` work.
 - Based on my testing on the development environment, the returned `Asset` data from the Asset Information API does not cause any problems when it's missing the `rentGroup` information _(even before this PR's change)_. However, going forward we're setting that interface to tell explicitly that this data is expected to be optional to capture any errors in future implementations relying on that data and interface.
 - Not all Assets are meant or are expected to have Rent Groups. Some Asset Types plain out can't have Rent Groups, while others may gain them, or may lose, or may change them depending on their relation status with the council.
 - I don't think it makes sense to have a property micro-frontend specific model: `CreateNewAssetRequest` and the related API call POST method within a `common` package. My understanding is that property micro-frontend should be the only MFE exposed to the management of Asset data. Therefore the model in question and the POST method should be of no use outside the `mtfh-microfronted-property` repository. We need to consider moving this functionality into the repository it's supposed to be in. 