### PR TITLE
Add "RentGroup" code descriptions.

### DIFF
--- a/lib/api/asset/v1/types.ts
+++ b/lib/api/asset/v1/types.ts
@@ -1,15 +1,15 @@
 export type AssetType = "Dwelling" | "LettableNonDwelling" | string;
 
 export enum RentGroup {
-  GPS = "GPS",
-  HGF = "HGF",
-  HRA = "HRA",
-  LMW = "LMW",
-  LSC = "LSC",
-  RSL = "RSL",
-  TAG = "TAG",
-  TAH = "TAH",
-  TRA = "TRA",
+  GPS = "Garages & Parking Spaces HRA",
+  HGF = "Housing General Fund",
+  HRA = "Housing Revenue Account",
+  LMW = "Leasehold Major Works",
+  LSC = "Leasehold Service Charges",
+  RSL = "Registered Social Landlord and XBorough",
+  TAG = "Temporary Accommodation General Fun",
+  TAH = "Temporary Accommodation HRA",
+  TRA = "Travellers General Fund",
 }
 
 export interface Asset {


### PR DESCRIPTION
# What:
 - Add full descriptions of the "Rent Group" codes.

# Why:
- The user feedback has suggested that not everyone using the "New Property" form is familiar with the Rent Group codes listed. Which raises a good point that wherever the Rent Group enum may be used, having access to full descriptions of the codes is of high value.

# Notes:
- This PR should be viewed as an add-on to the PR #290 , where the numeric enum was changed to a string enum. This time we're keeping it as a string enum, but expanding on the description value.
- This work relates to the Jira ticket: [HPT-48](https://hackney.atlassian.net/browse/HPT-48).

[HPT-48]: https://hackney.atlassian.net/browse/HPT-48?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ