### PR TITLE
Fix the 'RentGroup' enum 'TAG' key description typo.

### DIFF
--- a/lib/api/asset/v1/types.ts
+++ b/lib/api/asset/v1/types.ts
@@ -7,7 +7,7 @@ export enum RentGroup {
   LMW = "Leasehold Major Works",
   LSC = "Leasehold Service Charges",
   RSL = "Registered Social Landlord and XBorough",
-  TAG = "Temporary Accommodation General Fun",
+  TAG = "Temporary Accommodation General Fund",
   TAH = "Temporary Accommodation HRA",
   TRA = "Travellers General Fund",
 }


### PR DESCRIPTION
# What:
 - A typo fix for the '`RentGroup`' enum '`TAG`' key description.

# Notes:
 - Extends the PR #291 