### PR TITLE
Updates Tenure typings

### DIFF
--- a/lib/api/tenure/v1/types.ts
+++ b/lib/api/tenure/v1/types.ts
@@ -25,6 +25,7 @@ export interface TenureAsset {
   fullAddress: string;
   uprn: string;
   propertyReference: string | null;
+  isTemporaryAccommodation: boolean | null;
 }
 
 export interface AccountType {
@@ -46,6 +47,10 @@ export interface Charges {
   tenancyInsuranceCharge: number;
   originalRentCharge: number;
   originalServiceCharge: number;
+  storageCharge: number | null;
+  rentAdjustment: number | null;
+  rentAdjustmentReason: string | null;
+  isSuspended: boolean | null;
 }
 
 export interface AgreementType {
@@ -65,36 +70,45 @@ export interface LegacyReference {
   name: string;
   value: string;
 }
-
+export interface FurtherAccountInformation {
+  isRentAccountRequired: boolean;
+  noRentAccountReason: string;
+  rentLetterSentDate: string;
+  rentCardGivenDate: string;
+  tenureAcceptedDate: string;
+  isSection208NoticeSent: boolean;
+}
 export interface Tenure {
   id: string;
+  paymentReference: string;
+  householdMembers: HouseholdMember[];
   tenuredAsset: TenureAsset;
+  charges: Charges;
   startOfTenureDate: string;
   endOfTenureDate: string | null;
   tenureType: TenureType;
+  tenureSource: string | null;
   isActive: boolean;
-  accountType: AccountType;
-  paymentReference: string;
-  householdMembers: HouseholdMember[];
-  charges: Charges;
   isTenanted: boolean | null;
   terminated: {
     isTerminated: boolean;
     reasonForTermination: string;
   };
   successionDate: string;
-  agreementType: AgreementType;
-  subsidiaryAccountsReferences: string[];
-  masterAccountTenureReference: string;
   evictionDate: string;
   potentialEndDate: string;
-  notices: NoticeType[];
-  legacyReferences: LegacyReference[];
-  rentCostCentre: string;
   isMutualExchange: boolean;
   informHousingBenefitsForChanges: boolean;
   isSublet: boolean;
   subletEndDate: string;
+  notices: NoticeType[];
+  legacyReferences: LegacyReference[];
+  agreementType: AgreementType;
+  fundingSource: string;
+  numberOfAdultsInProperty: number;
+  numberOfChildrenInProperty: number;
+  hasOffsiteStorage: boolean;
+  furtherAccountInformation: FurtherAccountInformation;
   etag?: string;
 }
 

--- a/lib/api/tenure/v1/types.ts
+++ b/lib/api/tenure/v1/types.ts
@@ -71,12 +71,12 @@ export interface LegacyReference {
   value: string;
 }
 export interface FurtherAccountInformation {
-  isRentAccountRequired: boolean;
-  noRentAccountReason: string;
-  rentLetterSentDate: string;
-  rentCardGivenDate: string;
-  tenureAcceptedDate: string;
-  isSection208NoticeSent: boolean;
+  isRentAccountRequired: boolean | null;
+  noRentAccountReason: string | null;
+  rentLetterSentDate: string | null;
+  rentCardGivenDate: string | null;
+  tenureAcceptedDate: string | null;
+  isSection208NoticeSent: boolean | null;
 }
 export interface Tenure {
   id: string;
@@ -104,11 +104,15 @@ export interface Tenure {
   notices: NoticeType[];
   legacyReferences: LegacyReference[];
   agreementType: AgreementType;
-  fundingSource: string;
-  numberOfAdultsInProperty: number;
-  numberOfChildrenInProperty: number;
-  hasOffsiteStorage: boolean;
-  furtherAccountInformation: FurtherAccountInformation;
+  fundingSource: string | null;
+  numberOfAdultsInProperty: number | null;
+  numberOfChildrenInProperty: number | null;
+  hasOffsiteStorage: boolean | null;
+  furtherAccountInformation: FurtherAccountInformation | null;
+  rentCostCentre: string;
+  subsidiaryAccountsReferences: string[];
+  masterAccountTenureReference: string;
+  accountType: AccountType;
   etag?: string;
 }
 

--- a/lib/api/tenure/v1/types.ts
+++ b/lib/api/tenure/v1/types.ts
@@ -73,9 +73,9 @@ export interface LegacyReference {
 export interface FurtherAccountInformation {
   isRentAccountRequired: boolean | null;
   noRentAccountReason: string | null;
-  rentLetterSentDate: string | null;
-  rentCardGivenDate: string | null;
-  tenureAcceptedDate: string | null;
+  rentLetterSentDate: Date | null;
+  rentCardGivenDate: Date | null;
+  tenureAcceptedDate: Date | null;
   isSection208NoticeSent: boolean | null;
 }
 export interface Tenure {


### PR DESCRIPTION
https://hackney.atlassian.net/browse/TS-1362?atlOrigin=eyJpIjoiZjY1MmM0ZDJjZTc2NDk3ZGJiZWJhMDUxNmJkMmQxMGUiLCJwIjoiaiJ9 

**What** 
Updates the Tenure type object.

**Why**
We are trying where possible to use functionality that already exists in common. Currently, we replicate some elements of the hooks and services in the TA application. For consistency, testing and minimising replication we want to reduce this.

In order to use the Tenure features from common, the typings need to be updated to match the response. Some types are missing, and others appear to not be in use.

I'm not sure how widely used/where else this api is used. So would be good to get some ideas on where else the change might need to be tested out. 

**How**
This updates tenure/v1/types object.


