### PR TITLE
corrects personTenureType to be optional prop

### DIFF
--- a/lib/api/tenure/v1/types.ts
+++ b/lib/api/tenure/v1/types.ts
@@ -25,7 +25,7 @@ export interface TenureAsset {
   fullAddress: string;
   uprn: string;
   propertyReference: string | null;
-  isTemporaryAccommodation: boolean | null;
+  isTemporaryAccommodation?: boolean | null;
 }
 
 export interface AccountType {


### PR DESCRIPTION
**Adds optional to isTemporaryAccomodation prop**

https://hackney.atlassian.net/browse/TS-1362?atlOrigin=eyJpIjoiZjY1MmM0ZDJjZTc2NDk3ZGJiZWJhMDUxNmJkMmQxMGUiLCJwIjoiaiJ9

What
Updates the Tenure type object.

Why
We are trying where possible to use functionality that already exists in common. Currently, we replicate some elements of the hooks and services in the TA application. For consistency, testing and minimising replication we want to reduce this.

In order to use the Tenure features from common, the typings need to be updated to match the response. Some types are missing, and others appear to not be in use.

I'm not sure how widely used/where else this api is used. So would be good to get some ideas on where else the change might need to be tested out.

How
This updates tenure/v1/types object.
