### PR TITLE
Add tempAccInfo to tenure

### DIFF
--- a/lib/api/tenure/v1/service.test.ts
+++ b/lib/api/tenure/v1/service.test.ts
@@ -121,6 +121,8 @@ describe("when editTenure is called", () => {
       paymentReference: "1234567890",
       startOfTenureDate: "2021-01-01",
       endOfTenureDate: "2024-01-01",
+      taOfficer: "Firstname Lastname",
+      taStatus: "Accepted",
     };
     const response = {
       data: {},
@@ -135,6 +137,8 @@ describe("when editTenure is called", () => {
         paymentReference: params.paymentReference,
         startOfTenureDate: params.startOfTenureDate,
         endOfTenureDate: params.endOfTenureDate,
+        taOfficer: params.taOfficer,
+        taStatus: params.taStatus,
       },
     );
     expect(editTenureResponse).toBe(response.data);

--- a/lib/api/tenure/v1/service.test.ts
+++ b/lib/api/tenure/v1/service.test.ts
@@ -121,8 +121,14 @@ describe("when editTenure is called", () => {
       paymentReference: "1234567890",
       startOfTenureDate: "2021-01-01",
       endOfTenureDate: "2024-01-01",
-      taOfficer: "Firstname Lastname",
-      taStatus: "Accepted",
+      tempAccInfo: {
+        bookingStatus: "Confirmed",
+        assignedOfficer: {
+          firstName: "Firstname",
+          lastName: "Lastname",
+          email: "firstname.lastname@hackney.gov.uk",
+        },
+      },
     };
     const response = {
       data: {},
@@ -137,8 +143,7 @@ describe("when editTenure is called", () => {
         paymentReference: params.paymentReference,
         startOfTenureDate: params.startOfTenureDate,
         endOfTenureDate: params.endOfTenureDate,
-        taOfficer: params.taOfficer,
-        taStatus: params.taStatus,
+        tempAccInfo: params.tempAccInfo,
       },
     );
     expect(editTenureResponse).toBe(response.data);

--- a/lib/api/tenure/v1/service.ts
+++ b/lib/api/tenure/v1/service.ts
@@ -71,6 +71,8 @@ export interface EditTenureParams extends Partial<TenureParams> {
   id: string;
   etag: string;
   tenuredAsset?: TenureAsset | null;
+  taOfficer?: string;
+  taStatus?: string;
 }
 
 export const editTenure = async ({ id, ...data }: EditTenureParams): Promise<void> => {

--- a/lib/api/tenure/v1/service.ts
+++ b/lib/api/tenure/v1/service.ts
@@ -7,7 +7,13 @@ import {
   useAxiosSWR,
 } from "@mtfh/common/lib/http";
 
-import { HouseholdMember, Tenure, TenureAsset, TenureType } from "./types";
+import {
+  HouseholdMember,
+  TemporaryAccommodationInfo,
+  Tenure,
+  TenureAsset,
+  TenureType,
+} from "./types";
 
 export const useTenure = (
   id: string | null,
@@ -71,8 +77,7 @@ export interface EditTenureParams extends Partial<TenureParams> {
   id: string;
   etag: string;
   tenuredAsset?: TenureAsset | null;
-  taOfficer?: string;
-  taStatus?: string;
+  tempAccInfo?: TemporaryAccommodationInfo;
 }
 
 export const editTenure = async ({ id, ...data }: EditTenureParams): Promise<void> => {

--- a/lib/api/tenure/v1/types.ts
+++ b/lib/api/tenure/v1/types.ts
@@ -113,6 +113,8 @@ export interface Tenure {
   subsidiaryAccountsReferences: string[];
   masterAccountTenureReference: string;
   accountType: AccountType;
+  taOfficer?: string;
+  taStatus?: string;
   etag?: string;
 }
 

--- a/lib/api/tenure/v1/types.ts
+++ b/lib/api/tenure/v1/types.ts
@@ -78,6 +78,18 @@ export interface FurtherAccountInformation {
   tenureAcceptedDate: Date | null;
   isSection208NoticeSent: boolean | null;
 }
+
+export interface TemporaryAccommodationOfficer {
+  firstName: string;
+  lastName: string;
+  email: string;
+}
+
+export interface TemporaryAccommodationInfo {
+  bookingStatus: string;
+  assignedOfficer: TemporaryAccommodationOfficer;
+}
+
 export interface Tenure {
   id: string;
   paymentReference: string;
@@ -113,8 +125,7 @@ export interface Tenure {
   subsidiaryAccountsReferences: string[];
   masterAccountTenureReference: string;
   accountType: AccountType;
-  taOfficer?: string;
-  taStatus?: string;
+  tempAccInfo: TemporaryAccommodationInfo;
   etag?: string;
 }
 

--- a/lib/api/tenure/v1/types.ts
+++ b/lib/api/tenure/v1/types.ts
@@ -125,7 +125,7 @@ export interface Tenure {
   subsidiaryAccountsReferences: string[];
   masterAccountTenureReference: string;
   accountType: AccountType;
-  tempAccInfo: TemporaryAccommodationInfo;
+  tempAccInfo?: TemporaryAccommodationInfo;
   etag?: string;
 }
 


### PR DESCRIPTION
[TS-1322](https://hackney.atlassian.net/browse/TS-1322) As a user - I want to be able to change the status of a booking - So that other officers in charge can pick it up and take the right actions.

Added `TemporaryAccommodationInfo` as an optional attribute to the `Tenure` data type and the `EditTenureParams` which is part of enabling the frontends to fetch and edit these attributes via the Tenure API.

See also: corresponding [Tenure API PR](https://github.com/LBHackney-IT/tenure-shared/pull/28)

This is needed so that the Temporary Accommodation frontend can allow users to view, filter by, and edit these attributes.

[TS-1322]: https://hackney.atlassian.net/browse/TS-1322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ