### PR TITLE
Partial TemporaryAccommodationInfo in EditTenureParams

### DIFF
--- a/lib/api/tenure/v1/service.ts
+++ b/lib/api/tenure/v1/service.ts
@@ -77,7 +77,7 @@ export interface EditTenureParams extends Partial<TenureParams> {
   id: string;
   etag: string;
   tenuredAsset?: TenureAsset | null;
-  tempAccInfo?: TemporaryAccommodationInfo;
+  tempAccInfo?: Partial<TemporaryAccommodationInfo>;
 }
 
 export const editTenure = async ({ id, ...data }: EditTenureParams): Promise<void> => {


### PR DESCRIPTION
This change allows clients such as the Temporary Accommodation worktray to support altering just the `bookingStatus` or just the `assignedOfficer` properties without supplying both.

Currently the client would always need to supply both even when updating one which is tricky because they are optional fields in the tenure search result - the client would need to "make up" a default value for an unset field.

Ultimately this gives clients more flexibility to edit specific tenure properties only.

