### PR TITLE
Rename tempAccInfo to tempAccommodationInfo

### DIFF
--- a/lib/api/tenure/v1/service.test.ts
+++ b/lib/api/tenure/v1/service.test.ts
@@ -121,7 +121,7 @@ describe("when editTenure is called", () => {
       paymentReference: "1234567890",
       startOfTenureDate: "2021-01-01",
       endOfTenureDate: "2024-01-01",
-      tempAccInfo: {
+      tempAccommodationInfo: {
         bookingStatus: "Confirmed",
         assignedOfficer: {
           firstName: "Firstname",
@@ -143,7 +143,7 @@ describe("when editTenure is called", () => {
         paymentReference: params.paymentReference,
         startOfTenureDate: params.startOfTenureDate,
         endOfTenureDate: params.endOfTenureDate,
-        tempAccInfo: params.tempAccInfo,
+        tempAccommodationInfo: params.tempAccommodationInfo,
       },
     );
     expect(editTenureResponse).toBe(response.data);

--- a/lib/api/tenure/v1/service.ts
+++ b/lib/api/tenure/v1/service.ts
@@ -73,11 +73,12 @@ export const removePersonFromTenure = async (
     `${config.tenureApiUrlV1}/tenures/${params.tenureId}/person/${params.householdMemberId}`,
   );
 };
+
 export interface EditTenureParams extends Partial<TenureParams> {
   id: string;
   etag: string;
   tenuredAsset?: TenureAsset | null;
-  tempAccInfo?: TemporaryAccommodationInfo;
+  tempAccommodationInfo?: TemporaryAccommodationInfo;
 }
 
 export const editTenure = async ({ id, ...data }: EditTenureParams): Promise<void> => {

--- a/lib/api/tenure/v1/types.ts
+++ b/lib/api/tenure/v1/types.ts
@@ -125,7 +125,7 @@ export interface Tenure {
   subsidiaryAccountsReferences: string[];
   masterAccountTenureReference: string;
   accountType: AccountType;
-  tempAccInfo?: TemporaryAccommodationInfo;
+  tempAccommodationInfo?: TemporaryAccommodationInfo;
   etag?: string;
 }
 


### PR DESCRIPTION
This corresponds with this [Tenure API Change](https://github.com/LBHackney-IT/tenure-shared/pull/29) and re-aligns the schemas

Property was renamed to avoid confusion with "temporary account"