### PR TITLE
Make booking status nullable

### DIFF
--- a/lib/api/tenure/v1/types.ts
+++ b/lib/api/tenure/v1/types.ts
@@ -86,7 +86,7 @@ export interface TemporaryAccommodationOfficer {
 }
 
 export interface TemporaryAccommodationInfo {
-  bookingStatus: string;
+  bookingStatus: string | null;
   assignedOfficer: TemporaryAccommodationOfficer;
 }
 

--- a/lib/api/tenure/v1/types.ts
+++ b/lib/api/tenure/v1/types.ts
@@ -86,7 +86,7 @@ export interface TemporaryAccommodationOfficer {
 }
 
 export interface TemporaryAccommodationInfo {
-  bookingStatus: string | null;
+  bookingStatus?: string | null;
   assignedOfficer: TemporaryAccommodationOfficer;
 }
 


### PR DESCRIPTION
This is to give clients the flexibility to send it as null in case there is no valid value to provide in requests to the tenure API