### PR TITLE
Updates types and methods to allow for new FurtherAccountInformation

### DIFF
--- a/lib/api/tenure/v1/service.test.ts
+++ b/lib/api/tenure/v1/service.test.ts
@@ -136,7 +136,7 @@ describe("when editTenure is called", () => {
         rentLetterSentDate: new Date("2024-01-01"),
         rentCardGivenDate: new Date("2023-01-01"),
         tenureAcceptedDate: new Date("2022-01-01"),
-        TenureRefusedDate: new Date("2022-01-01"),
+        tenureRefusedDate: new Date("2022-01-01"),
         isSection208NoticeSent: true,
       },
     };

--- a/lib/api/tenure/v1/service.test.ts
+++ b/lib/api/tenure/v1/service.test.ts
@@ -130,6 +130,15 @@ describe("when editTenure is called", () => {
           id: "987654321",
         },
       },
+      furtherAccountInformation: {
+        isRentAccountRequired: true,
+        noRentAccountReason: "No reason",
+        rentLetterSentDate: new Date("2024-01-01"),
+        rentCardGivenDate: new Date("2023-01-01"),
+        tenureAcceptedDate: new Date("2022-01-01"),
+        TenureRefusedDate: new Date("2022-01-01"),
+        isSection208NoticeSent: true,
+      },
     };
     const response = {
       data: {},
@@ -145,6 +154,7 @@ describe("when editTenure is called", () => {
         startOfTenureDate: params.startOfTenureDate,
         endOfTenureDate: params.endOfTenureDate,
         tempAccommodationInfo: params.tempAccommodationInfo,
+        furtherAccountInformation: params.furtherAccountInformation,
       },
     );
     expect(editTenureResponse).toBe(response.data);

--- a/lib/api/tenure/v1/service.ts
+++ b/lib/api/tenure/v1/service.ts
@@ -8,6 +8,7 @@ import {
 } from "@mtfh/common/lib/http";
 
 import {
+  FurtherAccountInformation,
   HouseholdMember,
   TemporaryAccommodationInfo,
   Tenure,
@@ -79,6 +80,7 @@ export interface EditTenureParams extends Partial<TenureParams> {
   etag: string;
   tenuredAsset?: TenureAsset | null;
   tempAccommodationInfo?: TemporaryAccommodationInfo;
+  furtherAccountInformation?: FurtherAccountInformation;
 }
 
 export const editTenure = async ({ id, ...data }: EditTenureParams): Promise<void> => {

--- a/lib/api/tenure/v1/types.ts
+++ b/lib/api/tenure/v1/types.ts
@@ -76,6 +76,7 @@ export interface FurtherAccountInformation {
   rentLetterSentDate: Date | null;
   rentCardGivenDate: Date | null;
   tenureAcceptedDate: Date | null;
+  TenureRefusedDate: Date | null;
   isSection208NoticeSent: boolean | null;
 }
 

--- a/lib/api/tenure/v1/types.ts
+++ b/lib/api/tenure/v1/types.ts
@@ -76,7 +76,7 @@ export interface FurtherAccountInformation {
   rentLetterSentDate: Date | null;
   rentCardGivenDate: Date | null;
   tenureAcceptedDate: Date | null;
-  TenureRefusedDate: Date | null;
+  tenureRefusedDate: Date | null;
   isSection208NoticeSent: boolean | null;
 }
 


### PR DESCRIPTION
**What**
Adds new TenureRefusedDate to the types, test and editTenure method

**Why**
We're using this field for TA officers to record a rejection of accommodation.