### PR TITLE
TS-1639 add sctructure query support for address search

### DIFF
--- a/lib/api/address/v1/service.test.ts
+++ b/lib/api/address/v1/service.test.ts
@@ -17,7 +17,6 @@ jest.mock("@mtfh/common/lib/http", () => ({
         data: {
           data: {
             address: "",
-            totalCount: 0,
           },
         },
       }),

--- a/lib/api/address/v1/service.test.ts
+++ b/lib/api/address/v1/service.test.ts
@@ -17,6 +17,7 @@ jest.mock("@mtfh/common/lib/http", () => ({
         data: {
           data: {
             address: "",
+            totalCount: 0,
           },
         },
       }),
@@ -28,12 +29,26 @@ jest.mock("@mtfh/common/lib/http", () => ({
 
 const postcode = "E8 1EA";
 
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
 describe("when searchAddress is called", () => {
   test("the request should be sent to the correct URL, with the correct postcode as a query parameter", async () => {
     await searchAddress(postcode);
 
     expect(axiosInstance.get).toBeCalledWith(
       `${config.addressApiUrlV1}/addresses?postcode=${postcode}`,
+      { headers: { "skip-x-correlation-id": true } },
+    );
+  });
+
+  test("when structure is requested the request should be sent to the correct URL, with the correct structure as a query parameter", async () => {
+    const structure = "Hierarchy";
+    await searchAddress(postcode, structure);
+
+    expect(axiosInstance.get).toBeCalledWith(
+      `${config.addressApiUrlV1}/addresses?postcode=${postcode}&Structure=${structure}`,
       { headers: { "skip-x-correlation-id": true } },
     );
   });

--- a/lib/api/address/v1/service.ts
+++ b/lib/api/address/v1/service.ts
@@ -4,22 +4,37 @@ import { AxiosSWRConfiguration, axiosInstance, useAxiosSWR } from "@mtfh/common/
 import type { Address } from "./types";
 
 export interface AddressAPIResponse {
-  data: { address: Address[] };
+  data: {
+    address: Address[];
+    total_count: number;
+  };
 }
 
 interface SearchAddressResponse {
   addresses?: Address[];
   error?: { code: number };
+  totalCount?: number;
 }
 
-export const searchAddress = async (postCode: string): Promise<SearchAddressResponse> =>
+export const searchAddress = async (
+  postCode: string,
+  structure?: string,
+): Promise<SearchAddressResponse> =>
   axiosInstance
-    .get<AddressAPIResponse>(`${config.addressApiUrlV1}/addresses?postcode=${postCode}`, {
-      headers: {
-        "skip-x-correlation-id": true,
+    .get<AddressAPIResponse>(
+      `${config.addressApiUrlV1}/addresses?postcode=${postCode}${
+        structure ? `&Structure=${structure}` : ""
+      }`,
+      {
+        headers: {
+          "skip-x-correlation-id": true,
+        },
       },
-    })
-    .then((res) => ({ addresses: res.data.data.address }))
+    )
+    .then((res) => ({
+      addresses: res.data.data.address,
+      totalCount: res.data.data.total_count,
+    }))
     .catch((res) => {
       if (res.message.toLowerCase().indexOf("network") !== -1) {
         return { error: { code: 500 } };

--- a/lib/api/address/v1/service.ts
+++ b/lib/api/address/v1/service.ts
@@ -6,14 +6,12 @@ import type { Address } from "./types";
 export interface AddressAPIResponse {
   data: {
     address: Address[];
-    total_count: number;
   };
 }
 
 interface SearchAddressResponse {
   addresses?: Address[];
   error?: { code: number };
-  totalCount?: number;
 }
 
 export const searchAddress = async (
@@ -33,7 +31,6 @@ export const searchAddress = async (
     )
     .then((res) => ({
       addresses: res.data.data.address,
-      totalCount: res.data.data.total_count,
     }))
     .catch((res) => {
       if (res.message.toLowerCase().indexOf("network") !== -1) {

--- a/lib/api/address/v1/types.ts
+++ b/lib/api/address/v1/types.ts
@@ -6,4 +6,5 @@ export interface Address {
   town: string;
   postcode: string;
   UPRN: number;
+  childAddresses?: Address[];
 }


### PR DESCRIPTION
This update adds support for the new structure query string parameter recently added to the address search API.

Address search V1 service has been updated to pass the `Structure` parameter to the API when requested. The service is not opinionated in terms of the value and simple passes the provided value as is.

`Address` type has also been updated to include `childAddresses` property which is now available in the address results.