### PR TITLE
TS-1963 Add support for searching by parent uprn

### DIFF
--- a/lib/api/address/v1/service.test.ts
+++ b/lib/api/address/v1/service.test.ts
@@ -64,6 +64,17 @@ describe("when getAddressViaUprn is called", () => {
       { headers: { "skip-x-correlation-id": true } },
     );
   });
+
+  test("the request should be sent to the correct URL, with correct UPRN as a query parameter when using parent UPRN", async () => {
+    const uprn = "0123456789";
+
+    await getAddressViaUprn(uprn, true);
+
+    expect(axiosInstance.get).toBeCalledWith(
+      `${config.addressApiUrlV1}/addresses?parentUprn=${uprn}`,
+      { headers: { "skip-x-correlation-id": true } },
+    );
+  });
 });
 
 describe("when useAddressLookup is called", () => {

--- a/lib/api/address/v1/service.ts
+++ b/lib/api/address/v1/service.ts
@@ -39,14 +39,22 @@ export const searchAddress = async (
       return res;
     });
 
-export const getAddressViaUprn = async (UPRN: string): Promise<SearchAddressResponse> => {
+export const getAddressViaUprn = async (
+  UPRN: string,
+  isParentUPRN?: boolean,
+): Promise<SearchAddressResponse> => {
   return new Promise<SearchAddressResponse>((resolve, reject) => {
     axiosInstance
-      .get<AddressAPIResponse>(`${config.addressApiUrlV1}/addresses?uprn=${UPRN}`, {
-        headers: {
-          "skip-x-correlation-id": true,
+      .get<AddressAPIResponse>(
+        `${config.addressApiUrlV1}/addresses?${
+          isParentUPRN ? `parentUprn` : `uprn`
+        }=${UPRN}`,
+        {
+          headers: {
+            "skip-x-correlation-id": true,
+          },
         },
-      })
+      )
       .then((res) => resolve({ addresses: res.data.data.address }))
       .catch((error) => reject(error));
   });


### PR DESCRIPTION
## WHAT
Update `getAddressViaUprn` function in address v1 service to support searching by parent UPRN.

## WHY
In some use cases we need to be able to search for addresses by their parent UPRN. This is required to support Temporary Accommodation block feature for example

## HOW
Add optional `isParentUPRN` parameter to `getAddressViaUprn` function. If set to true `parentUprn` is used in the query string instead of the deualt `uprn`.