### PR TITLE
TS-1963 Add paging support to getAddressViaUprn

### DIFF
--- a/lib/api/address/v1/service.test.ts
+++ b/lib/api/address/v1/service.test.ts
@@ -75,6 +75,33 @@ describe("when getAddressViaUprn is called", () => {
       { headers: { "skip-x-correlation-id": true } },
     );
   });
+
+  test("the request should be sent to the correct URL, with correct page as a query parameter when requested", async () => {
+    const uprn = "0123456789";
+    const isParentUPRN = undefined;
+    const page = 1;
+
+    await getAddressViaUprn(uprn, isParentUPRN, 1);
+
+    expect(axiosInstance.get).toBeCalledWith(
+      `${config.addressApiUrlV1}/addresses?uprn=${uprn}&page=${page}`,
+      { headers: { "skip-x-correlation-id": true } },
+    );
+  });
+
+  test("the request should be sent to the correct URL, with correct pageSize as a query parameter when requested", async () => {
+    const uprn = "0123456789";
+    const isParentUPRN = false;
+    const page = undefined;
+    const pageSize = 100;
+
+    await getAddressViaUprn(uprn, isParentUPRN, page, pageSize);
+
+    expect(axiosInstance.get).toBeCalledWith(
+      `${config.addressApiUrlV1}/addresses?uprn=${uprn}&pageSize=${pageSize}`,
+      { headers: { "skip-x-correlation-id": true } },
+    );
+  });
 });
 
 describe("when useAddressLookup is called", () => {

--- a/lib/api/address/v1/service.ts
+++ b/lib/api/address/v1/service.ts
@@ -42,13 +42,17 @@ export const searchAddress = async (
 export const getAddressViaUprn = async (
   UPRN: string,
   isParentUPRN?: boolean,
+  page?: number,
+  pageSize?: number,
 ): Promise<SearchAddressResponse> => {
   return new Promise<SearchAddressResponse>((resolve, reject) => {
     axiosInstance
       .get<AddressAPIResponse>(
         `${config.addressApiUrlV1}/addresses?${
           isParentUPRN ? `parentUprn` : `uprn`
-        }=${UPRN}`,
+        }=${UPRN}${page ? `&page=${page}` : ``}${
+          pageSize ? `&pageSize=${pageSize}` : ``
+        }`,
         {
           headers: {
             "skip-x-correlation-id": true,


### PR DESCRIPTION
## WHAT
Update `getAddressViaUprn ` to support `page` and `pageSize` query string parameters to support paging.

## WHY
In Addresses API the default page size is set to 50, so we only ever get maximum of 50 addresses without the ability to use paging. In Temporary Accommodation we need to be able to fetch all addresses with a given parent UPRN to support block functionality.

## HOW
Update `getAddressViaUprn` , so that clients can pass page and pageSize to achieve paging. Parameters are optional and are omitted altogether from the query string if values are not provided.