### PR TITLE
TS-1987 Add paging properties to search address response

### DIFF
--- a/lib/api/address/v1/service.test.ts
+++ b/lib/api/address/v1/service.test.ts
@@ -3,11 +3,23 @@ import { AxiosSWRConfiguration, axiosInstance, useAxiosSWR } from "@mtfh/common/
 
 import {
   AddressAPIResponse,
+  SearchAddressResponse,
   getAddressViaUprn,
   searchAddress,
   useAddressLookup,
 } from "./service";
 import { Address } from "./types";
+
+const PAGE_COUNT = 2;
+const TOTAL_COUNT = 70;
+
+const mockAddressAPIResponse: AddressAPIResponse = {
+  data: {
+    address: [],
+    page_count: PAGE_COUNT,
+    total_count: TOTAL_COUNT,
+  },
+};
 
 jest.mock("@mtfh/common/lib/http", () => ({
   ...jest.requireActual("@mtfh/common/lib/http"),
@@ -15,9 +27,7 @@ jest.mock("@mtfh/common/lib/http", () => ({
     get: jest.fn().mockImplementation(() =>
       Promise.resolve({
         data: {
-          data: {
-            address: "",
-          },
+          ...mockAddressAPIResponse,
         },
       }),
     ),
@@ -101,6 +111,14 @@ describe("when getAddressViaUprn is called", () => {
       `${config.addressApiUrlV1}/addresses?uprn=${uprn}&pageSize=${pageSize}`,
       { headers: { "skip-x-correlation-id": true } },
     );
+  });
+
+  test("the response contains correct paging properties and values", async () => {
+    const uprn = "0123456789";
+    const response: SearchAddressResponse = await getAddressViaUprn(uprn);
+
+    expect(response.pageCount).toBe(PAGE_COUNT);
+    expect(response.totalCount).toBe(TOTAL_COUNT);
   });
 });
 

--- a/lib/api/address/v1/service.ts
+++ b/lib/api/address/v1/service.ts
@@ -6,11 +6,15 @@ import type { Address } from "./types";
 export interface AddressAPIResponse {
   data: {
     address: Address[];
+    page_count: number;
+    total_count: number;
   };
 }
 
-interface SearchAddressResponse {
+export interface SearchAddressResponse {
   addresses?: Address[];
+  pageCount: number;
+  totalCount: number;
   error?: { code: number };
 }
 
@@ -59,7 +63,13 @@ export const getAddressViaUprn = async (
           },
         },
       )
-      .then((res) => resolve({ addresses: res.data.data.address }))
+      .then((res) =>
+        resolve({
+          addresses: res.data.data.address,
+          pageCount: res.data.data.page_count,
+          totalCount: res.data.data.total_count,
+        }),
+      )
       .catch((error) => reject(error));
   });
 };

--- a/lib/api/address/v1/service.ts
+++ b/lib/api/address/v1/service.ts
@@ -6,15 +6,15 @@ import type { Address } from "./types";
 export interface AddressAPIResponse {
   data: {
     address: Address[];
-    page_count: number;
-    total_count: number;
+    page_count?: number;
+    total_count?: number;
   };
 }
 
 export interface SearchAddressResponse {
   addresses?: Address[];
-  pageCount: number;
-  totalCount: number;
+  pageCount?: number;
+  totalCount?: number;
   error?: { code: number };
 }
 


### PR DESCRIPTION
Add optional `pageCount` and `totalCount` properties to the `SearchAddressResponse`, so clients can use the paging provided by the Addresses API. This was accidentally left out in the previous paging update PR. 

Also exports the `SearchAddressResponse`, so it can be used in tests etc. in other MFEs.