### PR TITLE
TS-2072 add pre-production workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -406,147 +406,147 @@ jobs:
 
 workflows:
   version: 2
-  # continuous-delivery-development:
-  #   when: << pipeline.parameters.run_development_workflow >>
-  #   jobs:
-  #     - install-dependencies
-  #     - lint-and-test:
-  #         requires:
-  #           - install-dependencies
-  #     # - security-scan:
-  #     #     context: mtfh-security-scan
-  #     #     requires:
-  #     #       - lint-and-test
-  #     #     filters:
-  #     #       branches:
-  #     #         only: main
-  #     - permit-deploy-development:
-  #         type: approval
-  #         filters:
-  #           branches:
-  #             only: main
-  #     - assume-role-development:
-  #         context: api-assume-role-housing-development-context
-  #         requires:
-  #           # - security-scan
-  #           - lint-and-test
-  #           - permit-deploy-development
-  #         filters:
-  #           branches:
-  #             only: main
-  #     - terraform-init-and-apply-to-development:
-  #         requires:
-  #           - assume-role-development
-  #         filters:
-  #           branches:
-  #             only: main
-  #     - build-deploy-development:
-  #         stage: "development"
-  #         requires:
-  #           - terraform-init-and-apply-to-development
-  #         filters:
-  #           branches:
-  #             only: main
-  #     - trigger-e2e-pipeline:
-  #         context: mtfh-mfe-e2e-tests
-  #         stage: "development"
-  #         requires:
-  #           - build-deploy-development
-  #         filters:
-  #           branches:
-  #             only: main
+  continuous-delivery-development:
+    when: << pipeline.parameters.run_development_workflow >>
+    jobs:
+      - install-dependencies
+      - lint-and-test:
+          requires:
+            - install-dependencies
+      # - security-scan:
+      #     context: mtfh-security-scan
+      #     requires:
+      #       - lint-and-test
+      #     filters:
+      #       branches:
+      #         only: main
+      - permit-deploy-development:
+          type: approval
+          filters:
+            branches:
+              only: main
+      - assume-role-development:
+          context: api-assume-role-housing-development-context
+          requires:
+            # - security-scan
+            - lint-and-test
+            - permit-deploy-development
+          filters:
+            branches:
+              only: main
+      - terraform-init-and-apply-to-development:
+          requires:
+            - assume-role-development
+          filters:
+            branches:
+              only: main
+      - build-deploy-development:
+          stage: "development"
+          requires:
+            - terraform-init-and-apply-to-development
+          filters:
+            branches:
+              only: main
+      - trigger-e2e-pipeline:
+          context: mtfh-mfe-e2e-tests
+          stage: "development"
+          requires:
+            - build-deploy-development
+          filters:
+            branches:
+              only: main
 
-  # continuous-delivery-staging:
-  #   when: << pipeline.parameters.run_staging_workflow >>
-  #   jobs:
-  #     - permit-deploy-staging:
-  #         type: approval
-  #         filters:
-  #           branches:
-  #             only: main
-  #     - install-dependencies:
-  #         requires:
-  #           - permit-deploy-staging
-  #     - lint-and-test:
-  #         requires:
-  #           - install-dependencies
-  #     - assume-role-staging:
-  #         context: api-assume-role-housing-staging-context
-  #         requires:
-  #           - lint-and-test
-  #         filters:
-  #           branches:
-  #             only: main
-  #     - terraform-init-and-apply-to-staging:
-  #         requires:
-  #           - assume-role-staging
-  #         filters:
-  #           branches:
-  #             only: main
-  #     - build-deploy-staging:
-  #         stage: "staging"
-  #         requires:
-  #           - terraform-init-and-apply-to-staging
-  #         filters:
-  #           branches:
-  #             only: main
-  #     - trigger-e2e-pipeline:
-  #         context: mtfh-mfe-e2e-tests
-  #         stage: "staging"
-  #         requires:
-  #           - build-deploy-staging
-  #         filters:
-  #           branches:
-  #             only: main
+  continuous-delivery-staging:
+    when: << pipeline.parameters.run_staging_workflow >>
+    jobs:
+      - permit-deploy-staging:
+          type: approval
+          filters:
+            branches:
+              only: main
+      - install-dependencies:
+          requires:
+            - permit-deploy-staging
+      - lint-and-test:
+          requires:
+            - install-dependencies
+      - assume-role-staging:
+          context: api-assume-role-housing-staging-context
+          requires:
+            - lint-and-test
+          filters:
+            branches:
+              only: main
+      - terraform-init-and-apply-to-staging:
+          requires:
+            - assume-role-staging
+          filters:
+            branches:
+              only: main
+      - build-deploy-staging:
+          stage: "staging"
+          requires:
+            - terraform-init-and-apply-to-staging
+          filters:
+            branches:
+              only: main
+      - trigger-e2e-pipeline:
+          context: mtfh-mfe-e2e-tests
+          stage: "staging"
+          requires:
+            - build-deploy-staging
+          filters:
+            branches:
+              only: main
 
-  # continuous-delivery-production:
-  #   when: << pipeline.parameters.run_production_workflow >>
-  #   jobs:
-  #     - permit-production-terraform-release:
-  #         type: approval
-  #         filters:
-  #           branches:
-  #             only: main
-  #     - install-dependencies:
-  #         requires:
-  #           - permit-production-terraform-release
-  #     - lint-and-test:
-  #         requires:
-  #           - install-dependencies
-  #     - assume-role-production:
-  #         context: api-assume-role-housing-production-context
-  #         requires:
-  #           - lint-and-test
-  #         filters:
-  #           branches:
-  #             only: main
-  #     - terraform-init-and-apply-to-production:
-  #         requires:
-  #           - assume-role-production
-  #         filters:
-  #           branches:
-  #             only: main
-  #     - build-deploy-production:
-  #         stage: "production"
-  #         requires:
-  #           - terraform-init-and-apply-to-production
-  #         filters:
-  #           branches:
-  #             only: main
-  #     - trigger-e2e-pipeline:
-  #         context: mtfh-mfe-e2e-tests
-  #         stage: "production"
-  #         requires:
-  #           - build-deploy-production
-  #         filters:
-  #           branches:
-  #             only: main
+  continuous-delivery-production:
+    when: << pipeline.parameters.run_production_workflow >>
+    jobs:
+      - permit-production-terraform-release:
+          type: approval
+          filters:
+            branches:
+              only: main
+      - install-dependencies:
+          requires:
+            - permit-production-terraform-release
+      - lint-and-test:
+          requires:
+            - install-dependencies
+      - assume-role-production:
+          context: api-assume-role-housing-production-context
+          requires:
+            - lint-and-test
+          filters:
+            branches:
+              only: main
+      - terraform-init-and-apply-to-production:
+          requires:
+            - assume-role-production
+          filters:
+            branches:
+              only: main
+      - build-deploy-production:
+          stage: "production"
+          requires:
+            - terraform-init-and-apply-to-production
+          filters:
+            branches:
+              only: main
+      - trigger-e2e-pipeline:
+          context: mtfh-mfe-e2e-tests
+          stage: "production"
+          requires:
+            - build-deploy-production
+          filters:
+            branches:
+              only: main
 
-  # e2e-tests-failure:
-  #   when: << pipeline.parameters.e2e_test_failure >>
-  #   jobs:
-  #     - failure-downstream:
-  #         context: mtfh-mfe-e2e-tests
+  e2e-tests-failure:
+    when: << pipeline.parameters.e2e_test_failure >>
+    jobs:
+      - failure-downstream:
+          context: mtfh-mfe-e2e-tests
 
   deploy-terraform-pre-production:
     jobs:
@@ -554,7 +554,7 @@ workflows:
           type: approval
           filters:
             branches:
-              only: ts-2072-add-pre-production-workflows
+              only: main
       - assume-role-pre-production:
           context: api-assume-role-housing-pre-production-context
           requires:
@@ -576,7 +576,7 @@ workflows:
           type: approval
           filters:
             branches:
-              only: ts-2072-add-pre-production-workflows
+              only: main
       - install-dependencies:
           requires:
             - permit-pre-production-code-workflow

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,30 @@ commands:
           root: *workspace_root
           paths:
             - .aws
+  terraform-init-then-plan:
+    description: "Initializes and run plan from terraform configuration"
+    parameters:
+      environment:
+        type: string
+    steps:
+      - *attach_workspace
+      - checkout
+      - run:
+          command: |
+            cd ./terraform/<<parameters.environment>>/
+            terraform get -update=true
+            terraform init
+          name: get and init
+      - run:
+          name: plan
+          command: |
+            cd ./terraform/<<parameters.environment>>/
+            terraform plan -out=plan.out
+      - persist_to_workspace:
+          root: *workspace_root
+          paths:
+            - .aws
+            - project/*
 
   terraform-init-then-apply:
     description: "Initialize and apply the terraform configuration"
@@ -258,6 +282,53 @@ jobs:
             aws s3 sync dist s3://lbh-housing-tl-common-frontend-production.hackney.gov.uk/ --exclude "*.json" --cache-control "public, immutable, max-age=31536000"
             aws s3 sync dist s3://lbh-housing-tl-common-frontend-production.hackney.gov.uk/ --include "*.json" --cache-control "public, must-revalidate, max-age=0"
 
+  build-deploy-pre-production:
+    executor: node-executor
+    environment:
+      aws-region: eu-west-2
+    parameters:
+      stage:
+        type: string
+    steps:
+      - *attach_workspace
+      - aws-cli/install
+      - run:
+          name: build
+          command: |
+            export APP_ENV=pre-production
+            export APP_CDN=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/common-app-url --query Parameter.Value --output text)
+            export AUTH_ALLOWED_GROUPS=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/auth-allowed-groups --query Parameter.Value --output text)
+            export AUTH_DOMAIN=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/auth-domain --query Parameter.Value --output text)
+            export COOKIE_DOMAIN=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/cookie-domain --query Parameter.Value --output text)
+            export AUTH_TOKEN_NAME=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/auth-token-name --query Parameter.Value --output text)
+            export CONFIGURATION_API_URL_V1=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/configuration-api-url --query Parameter.Value --output text)
+            export CONTACT_DETAILS_API_URL_V1=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/contact-details-api-url --query Parameter.Value --output text)
+            export CONTACT_DETAILS_API_URL_V2=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/contact-details-api-url-v2 --query Parameter.Value --output text)
+            export CAUTIONARY_API_URL_V1=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/cautionary-api-url-v1 --query Parameter.Value --output text)
+            export PERSON_API_URL_V1=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/person-api-url --query Parameter.Value --output text)
+            export PERSON_API_URL_V2=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/person-api-url-v2 --query Parameter.Value --output text)
+            export NOTES_API_URL_V1=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/notes-api-url --query Parameter.Value --output text)
+            export NOTES_API_URL_V2=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/notes-api-url-v2 --query Parameter.Value --output text)
+            export TENURE_API_URL_V1=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/tenure-api-url --query Parameter.Value --output text)
+            export PROPERTY_API_URL_V1=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/property-api-url --query Parameter.Value --output text)
+            export REFERENCE_DATA_API_URL_V1=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/reference-data-api-url --query Parameter.Value --output text)
+            export ADDRESS_API_URL_V1=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/address-api-url --query Parameter.Value --output text)
+            export ADDRESS_API_URL_V2=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/address-api-url-v2 --query Parameter.Value --output text)
+            export EQUALITY_INFORMATION_API_URL_V1=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/equality-information-api-url --query Parameter.Value --output text)
+            export REPAIRS_HUB_APP_URL=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/repairs-hub-app-url --query Parameter.Value --output text)
+            export REPAIRS_HUB_API_URL=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/repairs-hub-api-url --query Parameter.Value --output text)
+            export PROCESS_API_URL_V1=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/process-api-url-v1 --query Parameter.Value --output text)
+            export PROCESS_API_URL_V2=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/process-api-url-v2 --query Parameter.Value --output text)
+            export HOUSING_FINANCE_INTERIM_API_URL_V1=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/housing-finance-interim-api-url --query Parameter.Value --output text)
+            export PATCHES_AND_AREAS_API_V1=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/patches-and-areas-api-url --query Parameter.Value --output text)
+            export HOUSINGSEARCH_API_URL_V1=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/search-api-url --query Parameter.Value --output text)
+            yarn build
+      - run:
+          name: Deploy to S3
+          command: |
+            aws s3 sync dist s3://lbh-housing-tl-common-frontend-pre-production.hackney.gov.uk/ --exclude "*.json" --cache-control "public, immutable, max-age=31536000"
+            aws s3 sync dist s3://lbh-housing-tl-common-frontend-pre-production.hackney.gov.uk/ --include "*.json" --cache-control "public, must-revalidate, max-age=0"
+
   assume-role-development:
     executor: docker-python
     steps:
@@ -316,140 +387,204 @@ jobs:
           echo downstream e2e tests have failed! Please check the e2e pipeline: ;
           echo -e 'https://circleci.com/api/v2/project/gh/LBHackney-IT/mtfh-tl-e2e-tests/pipeline' ;
           exit 1
+
+  assume-role-pre-production:
+    executor: docker-python
+    steps:
+      - assume-role-and-persist-workspace:
+          aws-account: $AWS_ACCOUNT_PRE_PRODUCTION
+  terraform-init-and-plan-pre-production:
+    executor: docker-terraform
+    steps:
+      - terraform-init-then-plan:
+          environment: "pre-production"
+  terraform-apply-pre-production:
+    executor: docker-terraform
+    steps:
+      - terraform-init-then-apply:
+          environment: "pre-production"
+
 workflows:
   version: 2
-  continuous-delivery-development:
-    when: << pipeline.parameters.run_development_workflow >>
-    jobs:
-      - install-dependencies
-      - lint-and-test:
-          requires:
-            - install-dependencies
-      # - security-scan:
-      #     context: mtfh-security-scan
-      #     requires:
-      #       - lint-and-test
-      #     filters:
-      #       branches:
-      #         only: main
-      - assume-role-development:
-          context: api-assume-role-housing-development-context
-          requires:
-            # - security-scan
-            - lint-and-test
-          filters:
-            branches:
-              only: main
-      - terraform-init-and-apply-to-development:
-          requires:
-            - assume-role-development
-          filters:
-            branches:
-              only: main
-      - build-deploy-development:
-          stage: "development"
-          requires:
-            - terraform-init-and-apply-to-development
-          filters:
-            branches:
-              only: main
-      - trigger-e2e-pipeline:
-          context: mtfh-mfe-e2e-tests
-          stage: "development"
-          requires:
-            - build-deploy-development
-          filters:
-            branches:
-              only: main
+  # continuous-delivery-development:
+  #   when: << pipeline.parameters.run_development_workflow >>
+  #   jobs:
+  #     - install-dependencies
+  #     - lint-and-test:
+  #         requires:
+  #           - install-dependencies
+  #     # - security-scan:
+  #     #     context: mtfh-security-scan
+  #     #     requires:
+  #     #       - lint-and-test
+  #     #     filters:
+  #     #       branches:
+  #     #         only: main
+  #     - permit-deploy-development:
+  #         type: approval
+  #         filters:
+  #           branches:
+  #             only: main
+  #     - assume-role-development:
+  #         context: api-assume-role-housing-development-context
+  #         requires:
+  #           # - security-scan
+  #           - lint-and-test
+  #           - permit-deploy-development
+  #         filters:
+  #           branches:
+  #             only: main
+  #     - terraform-init-and-apply-to-development:
+  #         requires:
+  #           - assume-role-development
+  #         filters:
+  #           branches:
+  #             only: main
+  #     - build-deploy-development:
+  #         stage: "development"
+  #         requires:
+  #           - terraform-init-and-apply-to-development
+  #         filters:
+  #           branches:
+  #             only: main
+  #     - trigger-e2e-pipeline:
+  #         context: mtfh-mfe-e2e-tests
+  #         stage: "development"
+  #         requires:
+  #           - build-deploy-development
+  #         filters:
+  #           branches:
+  #             only: main
 
-  continuous-delivery-staging:
-    when: << pipeline.parameters.run_staging_workflow >>
+  # continuous-delivery-staging:
+  #   when: << pipeline.parameters.run_staging_workflow >>
+  #   jobs:
+  #     - permit-deploy-staging:
+  #         type: approval
+  #         filters:
+  #           branches:
+  #             only: main
+  #     - install-dependencies:
+  #         requires:
+  #           - permit-deploy-staging
+  #     - lint-and-test:
+  #         requires:
+  #           - install-dependencies
+  #     - assume-role-staging:
+  #         context: api-assume-role-housing-staging-context
+  #         requires:
+  #           - lint-and-test
+  #         filters:
+  #           branches:
+  #             only: main
+  #     - terraform-init-and-apply-to-staging:
+  #         requires:
+  #           - assume-role-staging
+  #         filters:
+  #           branches:
+  #             only: main
+  #     - build-deploy-staging:
+  #         stage: "staging"
+  #         requires:
+  #           - terraform-init-and-apply-to-staging
+  #         filters:
+  #           branches:
+  #             only: main
+  #     - trigger-e2e-pipeline:
+  #         context: mtfh-mfe-e2e-tests
+  #         stage: "staging"
+  #         requires:
+  #           - build-deploy-staging
+  #         filters:
+  #           branches:
+  #             only: main
+
+  # continuous-delivery-production:
+  #   when: << pipeline.parameters.run_production_workflow >>
+  #   jobs:
+  #     - permit-production-terraform-release:
+  #         type: approval
+  #         filters:
+  #           branches:
+  #             only: main
+  #     - install-dependencies:
+  #         requires:
+  #           - permit-production-terraform-release
+  #     - lint-and-test:
+  #         requires:
+  #           - install-dependencies
+  #     - assume-role-production:
+  #         context: api-assume-role-housing-production-context
+  #         requires:
+  #           - lint-and-test
+  #         filters:
+  #           branches:
+  #             only: main
+  #     - terraform-init-and-apply-to-production:
+  #         requires:
+  #           - assume-role-production
+  #         filters:
+  #           branches:
+  #             only: main
+  #     - build-deploy-production:
+  #         stage: "production"
+  #         requires:
+  #           - terraform-init-and-apply-to-production
+  #         filters:
+  #           branches:
+  #             only: main
+  #     - trigger-e2e-pipeline:
+  #         context: mtfh-mfe-e2e-tests
+  #         stage: "production"
+  #         requires:
+  #           - build-deploy-production
+  #         filters:
+  #           branches:
+  #             only: main
+
+  # e2e-tests-failure:
+  #   when: << pipeline.parameters.e2e_test_failure >>
+  #   jobs:
+  #     - failure-downstream:
+  #         context: mtfh-mfe-e2e-tests
+
+  deploy-terraform-pre-production:
     jobs:
-      - permit-deploy-staging:
+      - permit-pre-production-terraform-workflow:
           type: approval
           filters:
             branches:
-              only: main
-      - install-dependencies:
+              only: ts-2072-add-pre-production-workflows
+      - assume-role-pre-production:
+          context: api-assume-role-housing-pre-production-context
           requires:
-            - permit-deploy-staging
-      - lint-and-test:
+            - permit-pre-production-terraform-workflow
+      - terraform-init-and-plan-pre-production:
           requires:
-            - install-dependencies
-      - assume-role-staging:
-          context: api-assume-role-housing-staging-context
+            - assume-role-pre-production
+      - permit-pre-production-terraform-deployment:
+          type: approval
           requires:
-            - lint-and-test
-          filters:
-            branches:
-              only: main
-      - terraform-init-and-apply-to-staging:
+            - terraform-init-and-plan-pre-production
+      - terraform-apply-pre-production:
           requires:
-            - assume-role-staging
-          filters:
-            branches:
-              only: main
-      - build-deploy-staging:
-          stage: "staging"
-          requires:
-            - terraform-init-and-apply-to-staging
-          filters:
-            branches:
-              only: main
-      - trigger-e2e-pipeline:
-          context: mtfh-mfe-e2e-tests
-          stage: "staging"
-          requires:
-            - build-deploy-staging
-          filters:
-            branches:
-              only: main
+            - permit-pre-production-terraform-deployment
 
-  continuous-delivery-production:
-    when: << pipeline.parameters.run_production_workflow >>
+  deploy-code-pre-production:
     jobs:
-      - permit-production-terraform-release:
+      - permit-pre-production-code-workflow:
           type: approval
           filters:
             branches:
-              only: main
+              only: ts-2072-add-pre-production-workflows
       - install-dependencies:
           requires:
-            - permit-production-terraform-release
-      - lint-and-test:
+            - permit-pre-production-code-workflow
+      - assume-role-pre-production:
+          context: api-assume-role-housing-pre-production-context
           requires:
             - install-dependencies
-      - assume-role-production:
-          context: api-assume-role-housing-production-context
+      - build-deploy-pre-production:
+          stage: pre-production
           requires:
-            - lint-and-test
-          filters:
-            branches:
-              only: main
-      - terraform-init-and-apply-to-production:
-          requires:
-            - assume-role-production
-          filters:
-            branches:
-              only: main
-      - build-deploy-production:
-          stage: "production"
-          requires:
-            - terraform-init-and-apply-to-production
-          filters:
-            branches:
-              only: main
-      - trigger-e2e-pipeline:
-          context: mtfh-mfe-e2e-tests
-          stage: "production"
-          requires:
-            - build-deploy-production
-          filters:
-            branches:
-              only: main
-
-  e2e-tests-failure:
-    when: << pipeline.parameters.e2e_test_failure >>
-    jobs:
-      - failure-downstream:
-          context: mtfh-mfe-e2e-tests
+            - assume-role-pre-production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -420,17 +420,11 @@ workflows:
       #     filters:
       #       branches:
       #         only: main
-      - permit-deploy-development:
-          type: approval
-          filters:
-            branches:
-              only: main
       - assume-role-development:
           context: api-assume-role-housing-development-context
           requires:
             # - security-scan
             - lint-and-test
-            - permit-deploy-development
           filters:
             branches:
               only: main

--- a/terraform/pre-production/aws_ssm_parameter.tf
+++ b/terraform/pre-production/aws_ssm_parameter.tf
@@ -226,18 +226,6 @@ resource "aws_ssm_parameter" "repairs_hub_api_url" {
   }
 }
 
-resource "aws_ssm_parameter" "process_api_url_v1" {
-  name  = "/housing-tl/${var.environment_display_name}/process-api-url-v1"
-  type  = "String"
-  value = "to_be_set_manually"
-
-  lifecycle {
-    ignore_changes = [
-      value,
-    ]
-  }
-}
-
 resource "aws_ssm_parameter" "process_api_url_v2" {
   name  = "/housing-tl/${var.environment_display_name}/process-api-url-v2"
   type  = "String"

--- a/terraform/pre-production/aws_ssm_parameter.tf
+++ b/terraform/pre-production/aws_ssm_parameter.tf
@@ -1,0 +1,275 @@
+resource "aws_ssm_parameter" "common_app_url" {
+  name  = "/housing-tl/${var.environment_display_name}/common-app-url"
+  type  = "String"
+  value = "to_be_set_manually"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "auth_allowed_groups" {
+  name  = "/housing-tl/${var.environment_display_name}/auth-allowed-groups"
+  type  = "String"
+  value = "to_be_set_manually"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "auth_domain" {
+  name  = "/housing-tl/${var.environment_display_name}/auth-domain"
+  type  = "String"
+  value = "to_be_set_manually"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "cookie_domain" {
+  name  = "/housing-tl/${var.environment_display_name}/cookie-domain"
+  type  = "String"
+  value = "to_be_set_manually"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "auth_token_name" {
+  name  = "/housing-tl/${var.environment_display_name}/auth-token-name"
+  type  = "String"
+  value = "to_be_set_manually"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "configuration_api_url" {
+  name  = "/housing-tl/${var.environment_display_name}/configuration-api-url"
+  type  = "String"
+  value = "to_be_set_manually"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "contact_details_api_url" {
+  name  = "/housing-tl/${var.environment_display_name}/contact-details-api-url"
+  type  = "String"
+  value = "to_be_set_manually"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "contact_details_api_url_v2" {
+  name  = "/housing-tl/${var.environment_display_name}/contact-details-api-url-v2"
+  type  = "String"
+  value = "to_be_set_manually"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "cautionary_api_url_v1" {
+  name  = "/housing-tl/${var.environment_display_name}/cautionary-api-url-v1"
+  type  = "String"
+  value = "to_be_set_manually"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "person_api_url_v2" {
+  name  = "/housing-tl/${var.environment_display_name}/person-api-url-v2"
+  type  = "String"
+  value = "to_be_set_manually"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "notes_api_url" {
+  name  = "/housing-tl/${var.environment_display_name}/notes-api-url"
+  type  = "String"
+  value = "to_be_set_manually"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "notes_api_url_v2" {
+  name  = "/housing-tl/${var.environment_display_name}/notes-api-url-v2"
+  type  = "String"
+  value = "to_be_set_manually"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "property_api_url" {
+  name  = "/housing-tl/${var.environment_display_name}/property-api-url"
+  type  = "String"
+  value = "to_be_set_manually"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "reference_data_api_url" {
+  name  = "/housing-tl/${var.environment_display_name}/reference-data-api-url"
+  type  = "String"
+  value = "to_be_set_manually"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "address_api_url" {
+  name  = "/housing-tl/${var.environment_display_name}/address-api-url"
+  type  = "String"
+  value = "to_be_set_manually"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "address_api_url_v2" {
+  name  = "/housing-tl/${var.environment_display_name}/address-api-url-v2"
+  type  = "String"
+  value = "to_be_set_manually"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "equality_information_api_url" {
+  name  = "/housing-tl/${var.environment_display_name}/equality-information-api-url"
+  type  = "String"
+  value = "to_be_set_manually"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "repairs_hub_app_url" {
+  name  = "/housing-tl/${var.environment_display_name}/repairs-hub-app-url"
+  type  = "String"
+  value = "to_be_set_manually"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "repairs_hub_api_url" {
+  name  = "/housing-tl/${var.environment_display_name}/repairs-hub-api-url"
+  type  = "String"
+  value = "to_be_set_manually"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "process_api_url_v1" {
+  name  = "/housing-tl/${var.environment_display_name}/process-api-url-v1"
+  type  = "String"
+  value = "to_be_set_manually"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "process_api_url_v2" {
+  name  = "/housing-tl/${var.environment_display_name}/process-api-url-v2"
+  type  = "String"
+  value = "to_be_set_manually"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "housing_finance_interim_api_url" {
+  name  = "/housing-tl/${var.environment_display_name}/housing-finance-interim-api-url"
+  type  = "String"
+  value = "to_be_set_manually"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "patches_and_areas_api_url" {
+  name  = "/housing-tl/${var.environment_display_name}/patches-and-areas-api-url"
+  type  = "String"
+  value = "to_be_set_manually"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}

--- a/terraform/pre-production/main.tf
+++ b/terraform/pre-production/main.tf
@@ -1,0 +1,133 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+terraform {
+  backend "s3" {
+    bucket         = "housing-pre-production-terraform-state"
+    encrypt        = true
+    region         = "eu-west-2"
+    key            = "services/t-and-l-common-frontend/state"
+    dynamodb_table = "housing-pre-production-terraform-state-lock"
+  }
+}
+
+
+resource "aws_s3_bucket" "frontend_bucket_pre_production" {
+  bucket = "lbh-housing-tl-common-frontend-${var.environment_display_name}.hackney.gov.uk"
+  tags = {
+    Name        = "mtfh-frontend-common bucket"
+    Environment = var.environment_name
+    Application = "MTFH Housing Pre-Production"
+    TeamEmail   = "developementteam@hackney.gov.uk"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "enable_encryption" {
+  bucket = aws_s3_bucket.frontend_bucket_pre_production.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "versioning" {
+  bucket = aws_s3_bucket.frontend_bucket_pre_production.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "block_public_access" {
+  bucket                  = aws_s3_bucket.frontend_bucket_pre_production.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+data "aws_iam_policy_document" "s3_allow_ssl_requests_only" {
+  statement {
+    sid     = "AllowSSLRequestsOnly"
+    effect  = "Deny"
+    actions = ["s3:*"]
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    resources = [
+      aws_s3_bucket.frontend_bucket_pre_production.arn,
+      "${aws_s3_bucket.frontend_bucket_pre_production.arn}/*",
+    ]
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values = [
+        "false"
+      ]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "bucket_policy" {
+  bucket = aws_s3_bucket.frontend_bucket_pre_production.id
+  policy = data.aws_iam_policy_document.s3_allow_ssl_requests_only.json
+}
+
+resource "aws_s3_bucket_cors_configuration" "cors" {
+  bucket = aws_s3_bucket.frontend_bucket_pre_production.id
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["GET"]
+    allowed_origins = [
+      "https://temporary-accommodation-pre-production.hackney.gov.uk/"
+    ]
+    expose_headers  = ["x-amz-server-side-encryption", "x-amz-request-id", "x-amz-id-2"]
+    max_age_seconds = 3000
+  }
+}
+
+resource "aws_s3_bucket_website_configuration" "website" {
+  bucket = aws_s3_bucket.frontend_bucket_pre_production.id
+
+  index_document {
+    suffix = "index.html"
+  }
+
+  error_document {
+    key = "error.html"
+  }
+}
+
+module "cloudfront_pre_production" {
+  source                       = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/cloudfront/s3_distribution"
+  s3_domain_name               = aws_s3_bucket.frontend_bucket_pre_production.bucket_regional_domain_name
+  origin_id                    = "mtfh-t-and-l-common-frontend"
+  s3_bucket_arn                = aws_s3_bucket.frontend_bucket_pre_production.arn
+  s3_bucket_id                 = aws_s3_bucket.frontend_bucket_pre_production.id
+  orginin_access_identity_desc = "T&L common frontend cloudfront identity"
+  cname_aliases                = []
+  environment_name             = var.environment_name
+  cost_code                    = "B0811"
+  project_name                 = var.project_name
+  use_cloudfront_cert          = true
+  compress                     = true
+}
+
+resource "aws_ssm_parameter" "cdn" {
+  name      = "/housing-tl/${var.environment_display_name}/common-app-url"
+  type      = "String"
+  value     = "https://${module.cloudfront_pre_production.cloudfront_domain_name}"
+  overwrite = true
+}

--- a/terraform/pre-production/variables.tf
+++ b/terraform/pre-production/variables.tf
@@ -1,0 +1,14 @@
+variable "environment_name" {
+  type    = string
+  default = "pre-prod"
+}
+
+variable "environment_display_name" {
+  type    = string
+  default = "pre-production"
+}
+
+variable "project_name" {
+  type    = string
+  default = "Housing-Pre-Production"
+}


### PR DESCRIPTION
[TS-2072](https://hackney.atlassian.net/browse/TS-2072)

This update adds pre-production resources and workflows.

New Terrraform `terraform-init-then-plan` command has been added, so it's possible to see terraform changes before appkying them. This has only been added to the new pre-production workflow.

Please note e2e test setup hasn't been added for pre-production. This is just the initial config to get the CloudFront distribution in place with the latest code.

Also adds all SSM parameter dependencies that haven't been added to the account yet.

[TS-2072]: https://hackney.atlassian.net/browse/TS-2072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ