### PR TITLE
Fix an issue where Patch Reassignment payload array gets deconstructed into an obect data structure.

### DIFF
--- a/lib/http/http.ts
+++ b/lib/http/http.ts
@@ -32,7 +32,10 @@ axiosInstance.interceptors.request.use((reqConfig) => {
   headers.delete("skip-x-correlation-id");
 
   // Handle ETag → If-Match for PATCH requests
-  const data = reqConfig.data ? { ...reqConfig.data } : undefined;
+  let data;
+  if (reqConfig.data) {
+    data = Array.isArray(reqConfig.data) ? [...reqConfig.data] : { ...reqConfig.data };
+  }
 
   if (reqConfig.method === "patch" && data?.etag) {
     headers.set("If-Match", data.etag);


### PR DESCRIPTION
# What:
 - Within Axios interceptor make the request data get destructured into appropriate data structures.

# Why:
As part of security upgrades work #324 , the axios interceptor was modified to meet the package higher version requirements. The changes involved copying any to-be-modified reference types so that the originals wouldn't get affected wherever they're stored.
 
 For the request payload this was done by destructuring its contents into an object: `{ ...reqConfig.data }`. This has caused an issue for the `PUT` `{id}/responsibleEntities` endpoint that passed its payload information not as an object, but as an array of: "responsible entities". This has caused the array to get destructured as an object where its first item would get assigned to "0" key, second item to "1" key, etc. Here is an example payload sento to an API:
```
{
    "0": {
        "name": "Test Test To do remove",
        "contactDetails": {
            "emailAddress": "this.patch.was.not.assigned@hackney.gov.uk"
        }
    }
}
```
when it should instead be:
```
[{
    "name": "Test Test To do remove",
    "contactDetails": {
        "emailAddress": "this.patch.was.not.assigned@hackney.gov.uk"
    }
}]
```

# Notes:
 - The regression was introduced only a couple days ago. No complaints were raised due to affected functionality rarely being needed _(patches assignments/reassignments to officers does not happen often)_.
 - The fix was already tested and confirmed to fix the issue on development environment by deploying via WIP dummy branch used for a different piece of work.
 - When `reqConfig.data` is falsy its copy is currently getting set to `undefined` to match the existing behaviour. Plus there's no case to handle what happens when it's not array or object, while being truthy. However, if any of the endpoints in the future ends up transporting its payload data as raw numbers or strings, this behaviour will need to be tweaked to set `data` to `reqConfig.data` when it's neither object nor array.