### PR TITLE
Add multi-client Cognito token verification support & decouple the Cognito client tests' fallback values from prod logic.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,9 +184,12 @@ jobs:
             export HOUSINGSEARCH_API_URL_V1=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/search-api-url --query Parameter.Value --output text)
             export COGNITO_TOKEN_NAME=$(aws ssm get-parameter --name arn:aws:ssm:eu-west-2:115283375626:parameter/housing-<<parameters.stage>>/mtfh-housing-<<parameters.stage>>/housing-tl/cognito-auth-token-name --query Parameter.Value --output text)
             export COGNITO_DOMAIN=$(aws ssm get-parameter --name arn:aws:ssm:eu-west-2:115283375626:parameter/housing-<<parameters.stage>>/mtfh-housing-<<parameters.stage>>/housing-tl/cognito-auth-domain --query Parameter.Value --output text)
-            export COGNITO_CLIENT_ID=$(aws ssm get-parameter --name arn:aws:ssm:eu-west-2:115283375626:parameter/housing-<<parameters.stage>>/mtfh-housing-<<parameters.stage>>/housing-tl/cognito-auth-client-id --query Parameter.Value --output text)
             export COGNITO_USER_POOL_ID=$(aws ssm get-parameter --name arn:aws:ssm:eu-west-2:115283375626:parameter/housing-<<parameters.stage>>/mtfh-housing-<<parameters.stage>>/housing-tl/cognito-auth-user-pool-id --query Parameter.Value --output text)
             export COGNITO_PKCE_VERIFIER_SESSION_STORAGE_NAME=$(aws ssm get-parameter --name arn:aws:ssm:eu-west-2:115283375626:parameter/housing-<<parameters.stage>>/mtfh-housing-<<parameters.stage>>/housing-tl/cognito-pkce-verifier-session-storage-name --query Parameter.Value --output text)
+
+            # Will get fully sorted out in a future PR after all other Cognito multi-client integration details are sorted out. For now a temp housing account ssm key is used.
+            # export COGNITO_CLIENT_ID=$(aws ssm get-parameter --name arn:aws:ssm:eu-west-2:115283375626:parameter/housing-<<parameters.stage>>/mtfh-housing-<<parameters.stage>>/housing-tl/cognito-auth-client-id --query Parameter.Value --output text)
+            export COGNITO_CLIENT_IDS=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/cognito-auth-client-ids --query Parameter.Value --output text)
 
             yarn build
       - run:

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,1 @@
+COGNITO_CLIENT_IDS={"mtfhClientId":"cognito-client-id-test-only","e2eTestsClientId":"cognito-client-id-test-only"}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,5 @@
+require("dotenv").config({ path: ".env.test" });
+
 module.exports = {
   rootDir: "lib",
   transform: {

--- a/lib/auth/auth.test.ts
+++ b/lib/auth/auth.test.ts
@@ -283,7 +283,9 @@ describe("auth", () => {
       await cognitoLogin();
 
       const expectedParams = new URLSearchParams({
-        client_id: config.cognitoClientId,
+        // Temp implementation until a better way is added
+        // assumes that the 1st one is for google sso login
+        client_id: config.cognitoClientIds[0],
         response_type: "code",
         scope: "openid email profile",
         redirect_uri: window.location.origin,
@@ -357,7 +359,9 @@ describe("auth", () => {
       expect(call.body.toString()).toBe(
         new URLSearchParams({
           grant_type: "authorization_code",
-          client_id: config.cognitoClientId,
+          // Temp implementation until a better way is added
+          // assumes that the 1st one is for google sso login
+          client_id: config.cognitoClientIds[0],
           code: mockAccessCode,
           redirect_uri: window.location.origin,
           code_verifier: generatedVerifier,

--- a/lib/auth/auth.test.ts
+++ b/lib/auth/auth.test.ts
@@ -283,9 +283,7 @@ describe("auth", () => {
       await cognitoLogin();
 
       const expectedParams = new URLSearchParams({
-        // Temp implementation until a better way is added
-        // assumes that the 1st one is for google sso login
-        client_id: config.cognitoClientIds[0],
+        client_id: config.cognitoClientIds.mtfhClientId,
         response_type: "code",
         scope: "openid email profile",
         redirect_uri: window.location.origin,
@@ -359,9 +357,7 @@ describe("auth", () => {
       expect(call.body.toString()).toBe(
         new URLSearchParams({
           grant_type: "authorization_code",
-          // Temp implementation until a better way is added
-          // assumes that the 1st one is for google sso login
-          client_id: config.cognitoClientIds[0],
+          client_id: config.cognitoClientIds.mtfhClientId,
           code: mockAccessCode,
           redirect_uri: window.location.origin,
           code_verifier: generatedVerifier,

--- a/lib/auth/auth.ts
+++ b/lib/auth/auth.ts
@@ -186,9 +186,7 @@ export const cognitoLogin = async (
   sessionStorage.setItem(config.cognitoPKCEVerifierSessionStorageName, codeVerifier);
 
   const params = new URLSearchParams({
-    // Temp implementation until a better way is added
-    // assumes that the 1st one is for google sso login
-    client_id: config.cognitoClientIds[0],
+    client_id: config.cognitoClientIds.mtfhClientId,
     response_type: "code",
     scope: "openid email profile",
     redirect_uri: redirectUrl,
@@ -207,9 +205,7 @@ export async function handleCognitoCallback(code: string): Promise<void> {
 
   const body = new URLSearchParams({
     grant_type: "authorization_code",
-    // Temp implementation until a better way is added
-    // assumes that the 1st one is for google sso login
-    client_id: config.cognitoClientIds[0],
+    client_id: config.cognitoClientIds.mtfhClientId,
     code,
     redirect_uri: window.location.origin,
     code_verifier: verifier ?? "", //Cognito will return 400 with invalid request if missing

--- a/lib/auth/auth.ts
+++ b/lib/auth/auth.ts
@@ -186,7 +186,9 @@ export const cognitoLogin = async (
   sessionStorage.setItem(config.cognitoPKCEVerifierSessionStorageName, codeVerifier);
 
   const params = new URLSearchParams({
-    client_id: config.cognitoClientId,
+    // Temp implementation until a better way is added
+    // assumes that the 1st one is for google sso login
+    client_id: config.cognitoClientIds[0],
     response_type: "code",
     scope: "openid email profile",
     redirect_uri: redirectUrl,
@@ -205,7 +207,9 @@ export async function handleCognitoCallback(code: string): Promise<void> {
 
   const body = new URLSearchParams({
     grant_type: "authorization_code",
-    client_id: config.cognitoClientId,
+    // Temp implementation until a better way is added
+    // assumes that the 1st one is for google sso login
+    client_id: config.cognitoClientIds[0],
     code,
     redirect_uri: window.location.origin,
     code_verifier: verifier ?? "", //Cognito will return 400 with invalid request if missing

--- a/lib/auth/cognitoVerifier.ts
+++ b/lib/auth/cognitoVerifier.ts
@@ -5,7 +5,7 @@ import { config } from "../config";
 export const cognitoVerifier = CognitoJwtVerifier.create({
   userPoolId: config.cognitoUserPoolId,
   tokenUse: "id",
-  // allows a str representing 1 client id, or an array of str
-  // of multiple client ids to verify against
-  clientId: config.cognitoClientIds,
+  // allows a str representing 1 client id,
+  // or a str[] of multiple client ids to verify against
+  clientId: Object.values(config.cognitoClientIds),
 });

--- a/lib/auth/cognitoVerifier.ts
+++ b/lib/auth/cognitoVerifier.ts
@@ -5,5 +5,7 @@ import { config } from "../config";
 export const cognitoVerifier = CognitoJwtVerifier.create({
   userPoolId: config.cognitoUserPoolId,
   tokenUse: "id",
-  clientId: config.cognitoClientId,
+  // allows a str representing 1 client id, or an array of str
+  // of multiple client ids to verify against
+  clientId: config.cognitoClientIds,
 });

--- a/lib/config/config.test.ts
+++ b/lib/config/config.test.ts
@@ -1,0 +1,56 @@
+describe("config", () => {
+  const originalEnv = process.env.COGNITO_CLIENT_IDS;
+
+  afterEach(() => {
+    if (originalEnv) {
+      process.env.COGNITO_CLIENT_IDS = originalEnv;
+    } else {
+      delete process.env.COGNITO_CLIENT_IDS;
+    }
+  });
+
+  describe("cognitoClientIds", () => {
+    test("parses valid JSON from COGNITO_CLIENT_IDS", async () => {
+      // arrange
+      process.env.COGNITO_CLIENT_IDS = JSON.stringify({
+        mtfhClientId: "test-client-id",
+        e2eTestsClientId: "e2e-client-id",
+      });
+
+      // act
+      jest.resetModules();
+      // Use dynamic import instead of require
+      const { default: freshConfig } = await import("./config");
+
+      // assert
+      expect(freshConfig.cognitoClientIds).toEqual({
+        mtfhClientId: "test-client-id",
+        e2eTestsClientId: "e2e-client-id",
+      });
+    });
+
+    test("throws error when COGNITO_CLIENT_IDS is not set", async () => {
+      // arrange
+      delete process.env.COGNITO_CLIENT_IDS;
+
+      // act, assert
+      jest.resetModules();
+
+      await expect(import("./config")).rejects.toThrow(
+        "COGNITO_CLIENT_IDS environment variable is required",
+      );
+    });
+
+    test("throws error when COGNITO_CLIENT_IDS contains invalid JSON", async () => {
+      // arrange
+      process.env.COGNITO_CLIENT_IDS = "{ invalid json }";
+
+      // act, assert
+      jest.resetModules();
+
+      await expect(import("./config")).rejects.toThrow(
+        "Failed to parse COGNITO_CLIENT_IDS environment variable",
+      );
+    });
+  });
+});

--- a/lib/config/config.ts
+++ b/lib/config/config.ts
@@ -1,3 +1,26 @@
+interface CognitoClientIds {
+  mtfhClientId: string;
+  e2eTestsClientId?: string;
+}
+
+function parseCognitoClientIds(): CognitoClientIds {
+  if (!process.env.COGNITO_CLIENT_IDS) {
+    return {
+      mtfhClientId: "cognito-client-id-test-only",
+      e2eTestsClientId: "cognito-client-id-test-only"
+    };
+  }
+
+  try {
+    return JSON.parse(process.env.COGNITO_CLIENT_IDS) as CognitoClientIds;
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Failed to parse COGNITO_CLIENT_IDS environment variable: ${errorMsg}`
+    );
+  }
+}
+
 const config = {
   appEnv: process.env.APP_ENV || "test",
   authAllowedGroups: process.env.AUTH_ALLOWED_GROUPS?.split(",") || ["TEST_GROUP"],
@@ -28,9 +51,7 @@ const config = {
     process.env.HOUSING_FINANCE_INTERIM_API_URL_V1 || "/api/v1",
   cognitoTokenName: process.env.COGNITO_TOKEN_NAME || "hackneyCognitoToken",
   cognitoDomain: process.env.COGNITO_DOMAIN || "cognito-domain-test-only",
-  cognitoClientIds: process.env.COGNITO_CLIENT_IDS?.split(",") || [
-    "cognito-client-id-test-only",
-  ],
+  cognitoClientIds: parseCognitoClientIds(),
   cognitoUserPoolId: process.env.COGNITO_USER_POOL_ID || "cognito-user-poll-id-test-only",
   cognitoPKCEVerifierSessionStorageName:
     process.env.COGNITO_PKCE_VERIFIER_SESSION_STORAGE_NAME ||

--- a/lib/config/config.ts
+++ b/lib/config/config.ts
@@ -7,7 +7,7 @@ function parseCognitoClientIds(): CognitoClientIds {
   if (!process.env.COGNITO_CLIENT_IDS) {
     return {
       mtfhClientId: "cognito-client-id-test-only",
-      e2eTestsClientId: "cognito-client-id-test-only"
+      e2eTestsClientId: "cognito-client-id-test-only",
     };
   }
 
@@ -15,9 +15,7 @@ function parseCognitoClientIds(): CognitoClientIds {
     return JSON.parse(process.env.COGNITO_CLIENT_IDS) as CognitoClientIds;
   } catch (error) {
     const errorMsg = error instanceof Error ? error.message : String(error);
-    throw new Error(
-      `Failed to parse COGNITO_CLIENT_IDS environment variable: ${errorMsg}`
-    );
+    throw new Error(`Failed to parse COGNITO_CLIENT_IDS environment variable: ${errorMsg}`);
   }
 }
 

--- a/lib/config/config.ts
+++ b/lib/config/config.ts
@@ -28,7 +28,9 @@ const config = {
     process.env.HOUSING_FINANCE_INTERIM_API_URL_V1 || "/api/v1",
   cognitoTokenName: process.env.COGNITO_TOKEN_NAME || "hackneyCognitoToken",
   cognitoDomain: process.env.COGNITO_DOMAIN || "cognito-domain-test-only",
-  cognitoClientId: process.env.COGNITO_CLIENT_ID || "cognito-client-id-test-only",
+  cognitoClientIds: process.env.COGNITO_CLIENT_IDS?.split(",") || [
+    "cognito-client-id-test-only",
+  ],
   cognitoUserPoolId: process.env.COGNITO_USER_POOL_ID || "cognito-user-poll-id-test-only",
   cognitoPKCEVerifierSessionStorageName:
     process.env.COGNITO_PKCE_VERIFIER_SESSION_STORAGE_NAME ||

--- a/lib/config/config.ts
+++ b/lib/config/config.ts
@@ -4,18 +4,18 @@ interface CognitoClientIds {
 }
 
 function parseCognitoClientIds(): CognitoClientIds {
-  if (!process.env.COGNITO_CLIENT_IDS) {
-    return {
-      mtfhClientId: "cognito-client-id-test-only",
-      e2eTestsClientId: "cognito-client-id-test-only",
-    };
+  const envVar = process.env.COGNITO_CLIENT_IDS;
+  if (!envVar) {
+    throw new Error("COGNITO_CLIENT_IDS environment variable is required");
   }
 
   try {
-    return JSON.parse(process.env.COGNITO_CLIENT_IDS) as CognitoClientIds;
+    return JSON.parse(envVar) as CognitoClientIds;
   } catch (error) {
     const errorMsg = error instanceof Error ? error.message : String(error);
-    throw new Error(`Failed to parse COGNITO_CLIENT_IDS environment variable: ${errorMsg}`);
+    throw new Error(
+      `Failed to parse COGNITO_CLIENT_IDS environment variable: ${errorMsg}`,
+    );
   }
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -102,7 +102,7 @@ module.exports = (webpackConfigEnv, argv) => {
         PATCHES_AND_AREAS_API_V1: dotenv.PATCHES_AND_AREAS_API_V1 || "",
         COGNITO_TOKEN_NAME: dotenv.COGNITO_TOKEN_NAME || "",
         COGNITO_DOMAIN: dotenv.COGNITO_DOMAIN || "",
-        COGNITO_CLIENT_ID: dotenv.COGNITO_CLIENT_ID || "",
+        COGNITO_CLIENT_IDS: dotenv.COGNITO_CLIENT_IDS || "",
         COGNITO_USER_POOL_ID: dotenv.COGNITO_USER_POOL_ID || "",
         COGNITO_PKCE_VERIFIER_SESSION_STORAGE_NAME:
           dotenv.COGNITO_PKCE_VERIFIER_SESSION_STORAGE_NAME || "",


### PR DESCRIPTION
# What:
 - Add support for verification of Cognito tokens originating from multiple Cognito App Clients.
 - Decouple the Common MFE tests' fallback values logic from production code.

# Why:
 - The E2E tests require their own dedicated Cognito Application Client. With the current support ALL of the E2E tests fail due to E2E tests Cognito Token not being able to get verified. Apart from E2E tests client, there's going to be more clients for various Next.js applications. We don't want users to need to log in every time they switch system.
 - Decoupled the logic so that the application would fail loudly when Cognito Application Client configuration is missing or malformed. Note, it does not check for whether the needed values within the configuration are set - the hope is that if the configuration is picked up, exists, and not malformed, then it will likely be correct as well.

# Note:
 - This release will only go as far as development environment. Before proceeding to environments past development, we'll do more work to get this refined environment variables-wise.