### PR TITLE
Prevent "void user" listen-trigger-push subscribe loop.

### DIFF
--- a/lib/auth/auth.ts
+++ b/lib/auth/auth.ts
@@ -104,7 +104,10 @@ export const parseToken = async (): Promise<void> => {
 
   // No token at all → return void user
   if (!legacyToken && !cognitoToken) {
-    $auth.next(voidUser);
+    const auth = $auth.getValue();
+    if (auth?.email !== "" && auth?.name !== "") {
+      $auth.next(voidUser);
+    }
     return;
   }
 


### PR DESCRIPTION
# What:
 - Prevent "void user" subscription loop while the token is not detected/set. 

# Why:
- Should yield less front-end login flickering and save some compute.
- Hopefully improves the reliability of E2E tests.

# Notes:
1. When no token is present **-->**
2. void user is published to `$auth` **-->**
3. Event fired off **-->**
4. Event detected by the `$auth` subscription, trigger function is fired off **-->**
5. Trigger runs Pop State event **-->**
6. Pop State event causes state re-evaluation **-->**
7. [Race condition between _(the auth flow setting the token)_ and _(token parsing checking the token)_] **-->**
8. If token remains unset by the time token parse is triggered, void user gets published to `$auth` again,  starting the loop over.

- Even with this in place, some flickering is unavoidable as  a considerable portion of it happens during the SPA initial load process.
- From my testing on local environment, I only ever experienced a couple of "void user" loops before the token and the actual user from it get initialised.