### PR TITLE
Temporarily disabled forced logout triggered by 403 API call responses.

### DIFF
--- a/lib/http/http.test.ts
+++ b/lib/http/http.test.ts
@@ -40,7 +40,8 @@ describe("axiosInstance", () => {
     );
   });
 
-  test("it will logout on 403", async () => {
+  // Un-skip it after Repairs is migrated to Cognito authentication, and this feature is re-enabled.
+  test.skip("it will logout on 403", async () => {
     $auth.next({
       token: "",
       sub: "",

--- a/lib/http/http.ts
+++ b/lib/http/http.ts
@@ -6,7 +6,9 @@ import axios, {
 } from "axios";
 import { v4 as uuid } from "uuid";
 
-import { $auth, isAuthorised, logout } from "@mtfh/common/lib/auth";
+import { $auth } from "@mtfh/common/lib/auth";
+// Add these back in when 403 forced logout is re-enabled
+// , isAuthorised, logout
 
 export interface Config extends AxiosRequestConfig {
   headers: AxiosHeaders;
@@ -60,9 +62,15 @@ axiosInstance.interceptors.response.use(
   },
   (error: AxiosError) => {
     if (error.response?.status === 403) {
-      if (isAuthorised()) {
-        logout();
-      }
+      // Has to be disabled for the until Repairs is moved onto the Cognito auth flow
+      // because repairs API calls failure due to mismatching authorizers are causing
+      // unwarranted logouts.
+      // if (isAuthorised()) {
+      //   logout();
+      // }
+      console.warn(
+        "This needs to be re-enabled after Repairs gets migrated onto Cognito authentication.",
+      );
     }
     throw error;
   },


### PR DESCRIPTION
# What:
 - Disabled forced logout on ANY 403 API response.

# Why:
 - Currently the integration between the MMH and Repairs is causing unwarranted forced logouts wherever an Asset page attempts fetching workorders. This is because the Repairs side hasn't been migrated to the new Cognito authorizer, so it does not acknowledge the Cognito token passed in the request headers.

# Notes:
 - This functionality will need to be re-enabled after repairs is migrated to Cognito auth flow. Work on this will only happen, however, after a green light is given by the TDA upon successful pen test.