### PR TITLE
SSI-1089 fix prod vulnerabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,5 +77,6 @@ dist
 yalc.lock
 
 # Local security analysis exports
-vulnerability-remediation-plan.html
+vulnerability-remediation-plan-*.html
+.audit-check.json
 

--- a/lib/http/http.test.ts
+++ b/lib/http/http.test.ts
@@ -117,10 +117,15 @@ describe("axiosInstance", () => {
     expect(res.data).toStrictEqual({ success: true });
   });
 
-  test("x-correlation-id is appended to the request headers", async () => {
+  test("x-correlation-id is appended to the request headers as a uuid v4", async () => {
+    const uuidV4Pattern =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+    let correlationId: string | null = null;
+
     server.use(
       rest.get("/api", (req, res, ctx) => {
-        if (req.headers?.has("x-correlation-id")) {
+        correlationId = req.headers.get("x-correlation-id");
+        if (correlationId) {
           return res.once(ctx.status(200));
         }
         return res.once(ctx.status(500));
@@ -130,6 +135,27 @@ describe("axiosInstance", () => {
     const res = await axiosInstance.get("/api");
 
     expect(res.status).toBe(200);
+    expect(correlationId).toMatch(uuidV4Pattern);
+    expect(res.config.headers.get("x-correlation-id")).toBe(correlationId);
+  });
+
+  test("x-correlation-id is unique on each request", async () => {
+    const correlationIds: string[] = [];
+
+    server.use(
+      rest.get("/api", (req, res, ctx) => {
+        correlationIds.push(req.headers.get("x-correlation-id") ?? "");
+        return res(ctx.status(200));
+      }),
+    );
+
+    await axiosInstance.get("/api");
+    await axiosInstance.get("/api");
+
+    expect(correlationIds).toHaveLength(2);
+    expect(correlationIds[0]).toBeTruthy();
+    expect(correlationIds[1]).toBeTruthy();
+    expect(correlationIds[0]).not.toBe(correlationIds[1]);
   });
 
   test("x-correlation-id is not appended to the request headers if skip-x-correlation-id is", async () => {

--- a/package.json
+++ b/package.json
@@ -96,10 +96,9 @@
     "@types/react-dom": "17.0.9",
     "@types/react-router-dom": "5.1.9",
     "@types/systemjs": "^6.1.0",
-    "@types/uuid": "^8.3.1",
     "@types/webpack-env": "^1.16.0",
     "aws-jwt-verify": "4.0.1",
-    "axios": "^1.16.0",
+    "axios": "^1.18.1",
     "classnames": "^2.3.1",
     "date-fns": "^2.23.0",
     "deep-diff": "^1.0.2",
@@ -114,10 +113,11 @@
     "single-spa": "^5.9.3",
     "swr": "1.0.1",
     "use-breakpoint": "^2.0.1",
-    "uuid": "^8.3.2"
+    "uuid": "^11.1.1"
   },
   "resolutions": {
     "@babel/runtime": "^7.26.10",
+    "form-data": "^4.0.6",
     "lodash-es": "^4.18.0",
     "react-router-dom/**/path-to-regexp": "1.9.0",
     "underscore": "^1.13.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2024,11 +2024,6 @@
   dependencies:
     "@types/jest" "*"
 
-"@types/uuid@^8.3.1":
-  version "8.3.1"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.1.tgz#1a32969cf8f0364b3d8c8af9cc3555b7805df14f"
-  integrity sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==
-
 "@types/webpack-env@^1.16.0":
   version "1.16.2"
   resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.16.2.tgz#8db514b059c1b2ae14ce9d7bb325296de6a9a0fa"
@@ -2676,10 +2671,10 @@ axe-core@^4.3.5:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.3.5.tgz#78d6911ba317a8262bfee292aeafcc1e04b49cc5"
   integrity sha512-WKTW1+xAzhMS5dJsxWkliixlO/PqC4VhmO9T4juNYcaTg9jzWiJsou6m5pxWYGfigWbwzJWeFY6z47a+4neRXA==
 
-axios@^1.16.0:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.17.0.tgz#ae5a1164a4f719942cd73c67e6a3f62d3ccb8f2b"
-  integrity sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==
+axios@^1.18.1:
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.18.1.tgz#d63f9863bcd8938815c86f9e2abd380189d96dfe"
+  integrity sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==
   dependencies:
     follow-redirects "^1.16.0"
     form-data "^4.0.5"
@@ -4771,27 +4766,16 @@ fork-ts-checker-webpack-plugin@^8.0.0:
     semver "^7.3.5"
     tapable "^2.2.1"
 
-form-data@^3.0.0:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.4.tgz#938273171d3f999286a4557528ce022dc2c98df1"
-  integrity sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==
+form-data@^3.0.0, form-data@^4.0.5, form-data@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.6.tgz#28e864e1b786dbebb68db1f452f9635278665827"
+  integrity sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     es-set-tostringtag "^2.1.0"
-    hasown "^2.0.2"
+    hasown "^2.0.4"
     mime-types "^2.1.35"
-
-form-data@^4.0.5:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.5.tgz#b49e48858045ff4cbf6b03e1805cebcad3679053"
-  integrity sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    es-set-tostringtag "^2.1.0"
-    hasown "^2.0.2"
-    mime-types "^2.1.12"
 
 formik@^2.2.9:
   version "2.2.9"
@@ -5147,6 +5131,13 @@ hasown@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.3.tgz#5e5c2b15b60370a4c7930c383dfb76bf17bc403c"
   integrity sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==
+  dependencies:
+    function-bind "^1.1.2"
+
+hasown@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
+  integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
   dependencies:
     function-bind "^1.1.2"
 
@@ -6860,7 +6851,7 @@ mime-db@^1.54.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.54.0.tgz#cddb3ee4f9c64530dff640236661d42cb6a314f5"
   integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
 
-mime-types@^2.1.12, mime-types@^2.1.31, mime-types@~2.1.17, mime-types@~2.1.24:
+mime-types@^2.1.31, mime-types@~2.1.17, mime-types@~2.1.24:
   version "2.1.33"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.33.tgz#1fa12a904472fafd068e48d9e8401f74d3f70edb"
   integrity sha512-plLElXp7pRDd0bNZHw+nMd52vRYjLwQjygaNg7ddJ2uJtTlmnTCjWuPKxVu6//AdaRuME84SvLW91sIkBqGT0g==
@@ -9481,12 +9472,17 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
+uuid@^11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
+
 uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.3.0, uuid@^8.3.2:
+uuid@^8.3.0:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
## Summary

Production security remediation — clears the remaining production-reachable audit findings.

- Upgrade `axios` to latest 1.x (`^1.18.1`)
- Upgrade `uuid` to `^11.1.1` (no application code changes)
- Add `form-data` resolution to `^4.0.6` (axios transitive dependency)

**Production-reachable advisories: 2 → 0**

## Security fixes

| Package | Before | After | Advisory |
|---------|--------|-------|----------|
| `form-data` (via `axios`) | `4.0.5` | `4.0.6` | CVE-2026-12143 (GHSA-hmw2-7cc7-3qxx) — CRLF injection |
| `uuid` | `8.3.2` | `11.1.1` | CVE-2026-41907 (GHSA-w5hq-g745-h8pq) — buffer bounds check |

## Changes

### `axios` (`^1.16.0` → `^1.18.1`)

Patch upgrade to latest 1.x. Used for all HTTP traffic in `lib/http/` and API services.

### `uuid` (`^8.3.2` → `^11.1.1`)

Major upgrade to clear the moderate production advisory. Existing usage unchanged:

```typescript
import { v4 as uuid } from "uuid";
```

- Removed `@types/uuid` — `uuid` 11 includes built-in TypeScript definitions
- `v4()` API remains compatible; no changes to `lib/http/http.ts`

### `form-data` (resolution `^4.0.6`)

`axios@1.18.1` still declares `form-data@^4.0.5`, which semver-allows `4.0.6` but Yarn kept resolving `4.0.5` in the lockfile. A targeted resolution forces the patched version without adding `form-data` as a direct dependency.

**Dependency path:** `axios` → `form-data`

## Impact

| Metric | Before | After |
|--------|--------|-------|
| Production-reachable advisories | 2 | **0** |
| Total audit findings | 414 | 407 |
| Application code changed | — | No |

## Lockfile

Targeted update (~50 lines in `yarn.lock`). No lockfile regeneration.

## Test plan

- [x] `yarn test:ci` — 354 tests passed
- [x] `yarn build` — passed
- [x] `yarn audit` — 0 production-reachable advisories
- [x] `lib/http/http.test.ts` — `x-correlation-id` is uuid v4 and unique per request
