### PR TITLE
SSI-1106 Re-enable logout on 403 response

### DIFF
--- a/lib/http/http.test.ts
+++ b/lib/http/http.test.ts
@@ -31,8 +31,7 @@ describe("axiosInstance", () => {
     );
   });
 
-  // Un-skip it after Repairs is migrated to Cognito authentication, and this feature is re-enabled.
-  test.skip("it will logout on 403", async () => {
+  test("it will logout on 403", async () => {
     $auth.next({
       token: "",
       sub: "",

--- a/lib/http/http.ts
+++ b/lib/http/http.ts
@@ -63,9 +63,6 @@ axiosInstance.interceptors.response.use(
       if (isAuthorised()) {
         logout();
       }
-      console.warn(
-        "This needs to be re-enabled after Repairs gets migrated onto Cognito authentication.",
-      );
     }
     throw error;
   },

--- a/lib/http/http.ts
+++ b/lib/http/http.ts
@@ -6,9 +6,7 @@ import axios, {
 } from "axios";
 import { v4 as uuid } from "uuid";
 
-import { $auth } from "@mtfh/common/lib/auth";
-// Add these back in when 403 forced logout is re-enabled
-// , isAuthorised, logout
+import { $auth, isAuthorised, logout } from "@mtfh/common/lib/auth";
 
 export interface Config extends AxiosRequestConfig {
   headers: AxiosHeaders;
@@ -62,12 +60,9 @@ axiosInstance.interceptors.response.use(
   },
   (error: AxiosError) => {
     if (error.response?.status === 403) {
-      // Has to be disabled for the until Repairs is moved onto the Cognito auth flow
-      // because repairs API calls failure due to mismatching authorizers are causing
-      // unwarranted logouts.
-      // if (isAuthorised()) {
-      //   logout();
-      // }
+      if (isAuthorised()) {
+        logout();
+      }
       console.warn(
         "This needs to be re-enabled after Repairs gets migrated onto Cognito authentication.",
       );


### PR DESCRIPTION
Repairs API and the authorizer it uses have been updated to support Cognito tokens all the way to prod, so the forced logout on 403 response can be re-enabled.

This reverts the changes made in #330 